### PR TITLE
Add word breaking to icon option label

### DIFF
--- a/lib/stylesheets/components/_oc_icon_option.scss
+++ b/lib/stylesheets/components/_oc_icon_option.scss
@@ -31,6 +31,8 @@
   .oc-icon-option__label {
     margin: 0;
     font-size: 13px;
+    word-break: break-word;
+    @include hyphens(auto);
   }
 
   .oc-icon-option__icon::before {


### PR DESCRIPTION
Fix the problem with icon option labels:

<img width="918" alt="screen shot 2016-10-17 at 9 04 11 am" src="https://cloud.githubusercontent.com/assets/17783867/20621961/bc823f02-b311-11e6-94c4-58f4d6c37be7.png">
