### PR TITLE
Extend NumberInput for currency edition

### DIFF
--- a/examples/basic/app.js
+++ b/examples/basic/app.js
@@ -141,6 +141,11 @@ const App = function App() {
           <h3>Long with commas</h3>
           <NumberInput width="100%" commas />
         </div>
+
+        <div className="clearfix">
+          <h3>Currency</h3>
+          <NumberInput width="25%" currency />
+        </div>
       </div>
 
       <hr />

--- a/lib/components/NumberInput.js
+++ b/lib/components/NumberInput.js
@@ -113,6 +113,7 @@ NumberInput.propTypes = {
   min: PropTypes.number,
   max: PropTypes.number,
   step: PropTypes.number,
+  currency: PropTypes.string,
   commas: PropTypes.bool,
   percents: PropTypes.bool,
   onBlur: PropTypes.func,

--- a/lib/components/NumberInput.js
+++ b/lib/components/NumberInput.js
@@ -74,13 +74,13 @@ class NumberInput extends React.Component {
     const { name, min, max, step, commas, percents, currency, type, width, onBlur } = this.props;
     let inputClass = classNames(
       'number-input__input',
-      { 'number-input__input--nan number-input__input--currency-input': currency },
+      { 'number-input__input--nan number-input__input--currency': currency },
       { 'number-input__input--nan': commas || type !== 'number' },
       { 'number-input__input--percents': percents },
     );
     return (
       <div className="number-input" style={{ width }}>
-        {currency && <span className='number-input__input--currency'/>}
+        {currency && <span className='number-input__span--currency'/>}
         <input
           ref="input"
           className={inputClass}

--- a/lib/components/NumberInput.js
+++ b/lib/components/NumberInput.js
@@ -38,7 +38,7 @@ class NumberInput extends React.Component {
     if (parseInt(nextValue, 10) <= props.min) {
       nextValue = props.min;
     }
-    nextValue = props.commas ? numberWithCommas(nextValue) : nextValue;
+    nextValue = (props.commas || props.currency) ? numberWithCommas(nextValue) : nextValue;
     return nextValue;
   }
 
@@ -71,19 +71,20 @@ class NumberInput extends React.Component {
   };
 
   render() {
-    const { name, min, max, step, commas, percents, type, width, onBlur } = this.props;
+    const { name, min, max, step, commas, percents, currency, type, width, onBlur } = this.props;
     let inputClass = classNames(
       'number-input__input',
-      { 'number-input__input--nan': commas || type !== 'number' },
+      { 'number-input__input--nan': commas || currency || type !== 'number' },
       { 'number-input__input--percents': percents },
     );
     return (
       <div className="number-input" style={{ width }}>
+        {currency && <span className='number-input__input--currency'/>}
         <input
           ref="input"
           className={inputClass}
-          type={commas ? 'text' : type}
-          pattern={(commas || percents) ? '.*' : '[0-9]*'}
+          type={commas || currency ? 'text' : type}
+          pattern={(commas || percents || currency) ? '.*' : '[0-9]*'}
           inputMode="numeric"
           lang="en"
           name={name}
@@ -92,11 +93,10 @@ class NumberInput extends React.Component {
           step={step}
           onBlur={(e) => (onBlur ? onBlur(e) : null)}
           onChange={this.handleChange}
-          value={this.state.value}
-        />
-        {percents && <span className="number-input__percents">%</span>}
-        <span className="number-input__minus" onClick={this.handleMinus} />
-        <span className="number-input__plus" onClick={this.handlePlus} />
+          value={this.state.value}/>
+        { percents && <span className="number-input__percents">%</span> }
+        { !currency && <span className="number-input__minus" onClick={this.handleMinus} /> }
+        { !currency && <span className="number-input__plus" onClick={this.handlePlus} /> }
       </div>
     );
   }

--- a/lib/components/NumberInput.js
+++ b/lib/components/NumberInput.js
@@ -74,7 +74,8 @@ class NumberInput extends React.Component {
     const { name, min, max, step, commas, percents, currency, type, width, onBlur } = this.props;
     let inputClass = classNames(
       'number-input__input',
-      { 'number-input__input--nan': commas || currency || type !== 'number' },
+      { 'number-input__input--nan number-input__input--currency-input': currency },
+      { 'number-input__input--nan': commas || type !== 'number' },
       { 'number-input__input--percents': percents },
     );
     return (

--- a/lib/stylesheets/components/_number_input.scss
+++ b/lib/stylesheets/components/_number_input.scss
@@ -51,17 +51,6 @@
     right: 15px;
   }
 
-  .number-input__input--currency {
-    @include cw-covericon-before(onlyclick-dollar, 0, $cwColor-black-light);
-    position: absolute;
-    left: 4px;
-    top: 4px;
-    height: 30px;
-    width: 30px;
-    font-size: 28px;
-    background-color: $cwColor-base-white;
-  }
-
   .number-input__input {
     width: calc(100% - 90px);
     height: 40px;
@@ -101,5 +90,22 @@
       top: 10px;
       pointer-events: none;
     }
+  }
+
+  .number-input__input--currency {
+    width: calc(100% - 30px);
+    @include cw-covericon-before(onlyclick-dollar, 0, $cwColor-black-light);
+    position: absolute;
+    left: 4px;
+    top: 4px;
+    height: 30px;
+    width: 30px;
+    font-size: 28px;
+    background-color: $cwColor-base-white;
+  }
+
+  .number-input__input--currency-input {
+    width: calc(100% - 10px);
+    padding-left: 35px;
   }
 }

--- a/lib/stylesheets/components/_number_input.scss
+++ b/lib/stylesheets/components/_number_input.scss
@@ -92,7 +92,7 @@
     }
   }
 
-  .number-input__input--currency {
+  .number-input__span--currency {
     width: calc(100% - 30px);
     @include cw-covericon-before(onlyclick-dollar, 0, $cwColor-black-light);
     position: absolute;
@@ -104,8 +104,8 @@
     background-color: $cwColor-base-white;
   }
 
-  .number-input__input--currency-input {
-    width: calc(100% - 10px);
+  .number-input__input--currency {
+    width: calc(100% - 8px);
     padding-left: 35px;
   }
 }

--- a/lib/stylesheets/components/_number_input.scss
+++ b/lib/stylesheets/components/_number_input.scss
@@ -51,6 +51,17 @@
     right: 15px;
   }
 
+  .number-input__input--currency {
+    @include cw-covericon-before(onlyclick-dollar, 0, $cwColor-black-light);
+    position: absolute;
+    left: 4px;
+    top: 4px;
+    height: 30px;
+    width: 30px;
+    font-size: 28px;
+    background-color: $cwColor-base-white;
+  }
+
   .number-input__input {
     width: calc(100% - 90px);
     height: 40px;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cw-components",
-  "version": "2.5.2",
+  "version": "2.5.3",
   "description": "CoverWallet components",
   "main": "./build/lib/index.js",
   "repository": {


### PR DESCRIPTION
### References

* **Pivotal Story:** https://www.pivotaltracker.com/story/show/140669537

### What is the goal?

Adding the `CurrencyInput` component that will be used for inputting currency amounts.

![image](https://cloud.githubusercontent.com/assets/379269/24120915/a18b3de8-0db6-11e7-8a35-776aaff2666f.png)

### How is it being implemented?

- Extending the `NumberInput` component for supporting an extra parameter (`currency`)
- Adding the new component mode to the examples page