### PR TITLE
Fix / ui issues

### DIFF
--- a/lib/stylesheets/components/_icons_radio_group.scss
+++ b/lib/stylesheets/components/_icons_radio_group.scss
@@ -3,9 +3,9 @@
 
   @include media($mobile) {
     @include flexbox();
-    flex-wrap: wrap;
-    align-content: center;
-    justify-content: center;
+    @include flex-wrap(wrap);
+    @include align-content(center);
+    @include justify-content(center);
   }
 }
 

--- a/lib/stylesheets/components/_oc_icon_options.scss
+++ b/lib/stylesheets/components/_oc_icon_options.scss
@@ -1,9 +1,9 @@
 .oc-icon-options {
   @include flexbox();
-  flex-wrap: wrap;
-  align-items: stretch;
-  align-content: space-between;
-  justify-content: flex-start;
+  @include flex-wrap(wrap);
+  @include align-items(stretch);
+  @include align-content(space-between);
+  @include justify-content(flex-start);
 
   margin: 10px 0 0;
 

--- a/lib/stylesheets/components/_oc_select.scss
+++ b/lib/stylesheets/components/_oc_select.scss
@@ -11,6 +11,7 @@
 
   .oc-select__search {
     @include flexbox();
+    @include flex-wrap(wrap);
     z-index: 1;
     padding: 6px 11px;
     border: 1px solid $cwColor-base-blue;
@@ -18,14 +19,13 @@
     cursor: text;
     position: relative;
     will-change: transform;
-    flex-wrap: wrap;
 
     @include media($mobile) {
       font-size: 15px;
     }
 
     .oc-select__input-container {
-      display: inline-flex;
+      @include display(inline-flex);
       width: 250px;
       max-width: 100%;
     }

--- a/lib/stylesheets/components/_oc_selected_value.scss
+++ b/lib/stylesheets/components/_oc_selected_value.scss
@@ -1,5 +1,5 @@
 .oc-selected-value {
-  display: inline-flex;
+  @include display(inline-flex);
   float: left;
   font-size: 0.9em;
   color: $cwColor-base-white;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cw-components",
-  "version": "2.5.5",
+  "version": "2.5.6",
   "description": "CoverWallet components",
   "main": "./build/lib/index.js",
   "repository": {


### PR DESCRIPTION
### References

* **Pivotal Story:** https://www.pivotaltracker.com/n/projects/1594861/stories/142018569

### What is the goal?

Fix displaying of cw-components on old versions of ios.

### How is it being implemented?

Use bourbon's mixins for flexbox's options.

**Caveats**

None.

### Impact

The components will properly be displayed on old versions of ios.
