### PR TITLE
[#142142737] Remove old style css class

### DIFF
--- a/lib/stylesheets/components/_oc_icon_options.scss
+++ b/lib/stylesheets/components/_oc_icon_options.scss
@@ -4,8 +4,7 @@
   @include align-items(stretch);
   @include align-content(space-between);
   @include justify-content(flex-start);
-
-  margin: 10px 0 0;
+  margin: 5px -10px 0 -10px;
 
   @include media($mobile) {
     justify-content: space-around;

--- a/lib/stylesheets/components/_oc_select.scss
+++ b/lib/stylesheets/components/_oc_select.scss
@@ -45,16 +45,17 @@
   }
 
   .oc-select__hint {
-    font-size: 13px;
-    font-weight: bold;
-    padding: 7px 15px;
-    color: $cwColor-base-white;
-    background-color: $cwColor-base-bluegray;
+    @include clearfix();
+    padding: 10px 1px 10px;
+    font-size: 14px;
+    line-height: 16px;
+    color: $cwColor-black-medium;
   }
+
 
   .oc-select__error {
     margin: 7px 0;
-    color: #f00;
+    color: $cwColor-base-red;
     font-size: 14px;
   }
 }


### PR DESCRIPTION
### References

Where
http://coverwallet.github.io/cw-components/basic/

* **Pivotal Story:** https://www.pivotaltracker.com/story/show/142142737
* **Rollbar items:** no

### What
The dark line
![screen shot 2017-03-29 at 15 03 21](https://cloud.githubusercontent.com/assets/1155574/24455712/efe61414-1490-11e7-9eec-dd916e3bb140.png)

### How
![screen shot 2017-03-29 at 15 03 39](https://cloud.githubusercontent.com/assets/1155574/24455718/f42a9b4e-1490-11e7-90f0-4231246e2c24.png)
