### PR TITLE
Extend flash messages

### DIFF
--- a/examples/basic/app.js
+++ b/examples/basic/app.js
@@ -103,7 +103,7 @@ const App = function App() {
         <CwFlashNotification
           type="info"
           title="Great! Now see your email account"
-          onClose={() => console.log('Close not defined in demo mode')}
+          onClose={() => console.log('Custom close event handler.')}
         />
       </div>
 
@@ -111,7 +111,7 @@ const App = function App() {
         <CwFlashNotification
           type="success"
           title="You're almost done"
-          onClose={() => console.log('Close not defined in demo mode')}
+          onClose={() => console.log('Custom close event handler.')}
         />
       </div>
 
@@ -119,7 +119,7 @@ const App = function App() {
         <CwFlashNotification
           type="error"
           title="Your payment could not be completed"
-          onClose={() => console.log('Close not defined in demo mode')}
+          onClose={() => console.log('Custom close event handler.')}
         />
       </div>
 
@@ -128,8 +128,17 @@ const App = function App() {
           type="info"
           title="Your account need to be activated"
           subtitle="Call (646) 844-9933 to purchase this policy"
-          onClose={() => console.log('Close not defined in demo mode')}
+          onClose={() => console.log('Custom close event handler.')}
         />
+      </div>
+
+      <div className="clearfix row">
+        <CwFlashNotification
+          type="info"
+          title="Your account need to be activated"
+        >
+          An additional info goes here.
+        </CwFlashNotification>
       </div>
 
       <div className="clearfix">

--- a/lib/components/CwFlashNotification.jsx
+++ b/lib/components/CwFlashNotification.jsx
@@ -2,38 +2,59 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 
-const CwFlashNotification = (props) => {
-  const { type, title, subtitle, onClose } = props;
-  const notificationClass = classNames(
-    'cw-flash-notification',
-    `cw-flash-notification--${type}`
-  );
+class CwFlashNotification extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      closed: false,
+    };
+  }
 
-  return (
-    <div className={notificationClass}>
-      <aside className="cw-flash-notification__icon-container">
-        <i className="cw-flash-notification__icon"></i>
-      </aside>
-      <div className="cw-flash-notification__content">
-        <h4 className="cw-flash-notification__title">{title}</h4>
-        {typeof subtitle !== 'undefined' && (<h5 className="cw-flash-notification__description">{subtitle}</h5>)}
+  closeNotification = () => {
+    this.setState({
+      closed: true,
+    })
+  };
+
+  render() {
+    const { closed } = this.state;
+    const { type, title, subtitle, onClose } = this.props;
+    if (!onClose && closed) {
+      return false;
+    }
+    const notificationClass = classNames(
+      'cw-flash-notification',
+      `cw-flash-notification--${type}`
+    );
+
+    const handleClose = onClose || this.closeNotification;
+
+    return (
+      <div className={notificationClass}>
+        <aside className="cw-flash-notification__icon-container">
+          <i className="cw-flash-notification__icon" />
+        </aside>
+        <div className="cw-flash-notification__content">
+          {title && <h4 className="cw-flash-notification__title">{title}</h4>}
+          {subtitle && <h5 className="cw-flash-notification__description">{subtitle}</h5>}
+          <div className="cw-flash-notification__text">{this.props.children}</div>
+        </div>
+        <div className="cw-flash-notification__controls">
+          <a className="cw-flash-notification__close" onClick={handleClose}>
+            <i className="cw-flash-notification__close-icon" />
+          </a>
+        </div>
       </div>
-      <div className="cw-flash-notification__controls">
-        {props.children}
-        <a className="cw-flash-notification__close" onClick={onClose}>
-          <i className="cw-flash-notification__close-icon"></i>
-        </a>
-      </div>
-    </div>
-  );
-};
+    );
+  }
+}
 
 CwFlashNotification.propTypes = {
   children: PropTypes.any,
   type: PropTypes.string.isRequired,
-  title: PropTypes.string.isRequired,
+  title: PropTypes.string,
   subtitle: PropTypes.string,
-  onClose: PropTypes.func.isRequired,
+  onClose: PropTypes.func,
 };
 
 export default CwFlashNotification;

--- a/lib/stylesheets/components/_cw_flash_notification.scss
+++ b/lib/stylesheets/components/_cw_flash_notification.scss
@@ -72,6 +72,14 @@
     margin: 0;
   }
 
+  &__text {
+    width: 100%;
+    font-size: 15px;
+    font-weight: 300;
+    line-height: 23px;
+    color: $cwColor-black-dark;
+  }
+
   &__controls {
     padding: 0 17px;
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cw-components",
-  "version": "2.6.0",
+  "version": "2.6.1",
   "description": "CoverWallet components",
   "main": "./build/lib/index.js",
   "repository": {


### PR DESCRIPTION
### Where

* **Pivotal Story:** None.

### What

Extend flash messages with default close behaviour and fix children displaying.

### How

If no `onClose` prop was passed use default close behaviour.

### Screenshots

**Before**
![screen shot 2017-05-16 at 12 17 59 pm](https://cloud.githubusercontent.com/assets/17783867/26098851/b912fa58-3a31-11e7-8e72-70fa6f49e0be.png)


**After**

![screen shot 2017-05-16 at 12 16 28 pm](https://cloud.githubusercontent.com/assets/17783867/26098852/baf060cc-3a31-11e7-9210-6a9bde2adb72.png)

### Test

Check flash messages section after deploying to gh-pages.

### Deployment

As usual.

### Warnings

None.
