### PR TITLE
Fixing lines disapears when click on ei11

### DIFF
--- a/lib/stylesheets/components/_keyboard.scss
+++ b/lib/stylesheets/components/_keyboard.scss
@@ -7,6 +7,10 @@
     display: none;
   }
 
+  &__row {
+    background-color: $cwColor-base-white;
+  }
+
   .keyboard__number, .keyboard__delete {
     cursor: pointer;
     width: 33.3%;
@@ -14,7 +18,6 @@
     text-align: center;
     line-height: 50px;
     color: $cwColor-base-bluegray;
-    background-color: $cwColor-base-white;
     border: 1px solid $cwColor-black-light;
     font-size: 16px;
     -webkit-user-select: none;  /* Chrome all / Safari all */
@@ -22,6 +25,7 @@
     -ms-user-select: none;      /* IE 10+ */
     user-select: none;
     box-sizing: border-box;
+
     &:hover {
       background-color: $cwColor-blue-light;
       color: $cwColor-base-white;
@@ -35,6 +39,7 @@
   .keyboard__delete {
     font-size: 24px;
     line-height: 47px;
+
     &:hover {
       &:before {
         background-color: $cwColor-blue-light;


### PR DESCRIPTION
### Where

* **Pivotal Story:** https://www.pivotaltracker.com/story/show/150355594
* **Rollbar Errors:** No.
* **Related PRs:** No.

### What

Lines on the number button selection disappears when you click on them using IE11.

### How

Adding some styles fixes.

**Before**

![screen shot 2017-10-06 at 11 31 06](https://user-images.githubusercontent.com/1155574/31272046-e00fbace-aa89-11e7-94d4-aa5fe07644b5.png)

**After**

![screen shot 2017-10-06 at 11 30 50](https://user-images.githubusercontent.com/1155574/31272052-e5764d7a-aa89-11e7-9605-42f37da43493.png)
