### PR TITLE
[#151246943] X in fields is not according to design on IE11

### DIFF
--- a/lib/stylesheets/components/_common.scss
+++ b/lib/stylesheets/components/_common.scss
@@ -1,4 +1,4 @@
 // Bug solved: X icon appears when typing IE11
-input::-ms-clear {
+input[type="text"]::-ms-clear {
   display: none;
 }

--- a/lib/stylesheets/components/_common.scss
+++ b/lib/stylesheets/components/_common.scss
@@ -1,0 +1,4 @@
+// Bug solved: X icon appears when typing IE11
+input::-ms-clear {
+  display: none;
+}

--- a/lib/stylesheets/components/_components.scss
+++ b/lib/stylesheets/components/_components.scss
@@ -11,3 +11,4 @@
 @import 'oc_selected_value';
 @import 'oc_select';
 @import 'cw_flash_notification';
+@import 'common';

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cw-components",
-  "version": "2.7.4",
+  "version": "2.7.5",
   "description": "CoverWallet components",
   "main": "./build/lib/index.js",
   "repository": {


### PR DESCRIPTION
### Where

* **Pivotal Story:** https://www.pivotaltracker.com/story/show/151246943
* **Rollbar Errors:** No.
* **Related PRs:** No.

### What

if you go to any bar to complete and you will see the X before saving it.

### How

Applying the ::-ms-clear CSS pseudo-element which represents a button (the "clear button") at the edge of a text <input> which clears away the current value of the <input> element. 

**Before**

![screen shot 2017-10-13 at 15 33 30](https://user-images.githubusercontent.com/1155574/31548722-18d65e88-b02c-11e7-9cc0-a7df9dae6e58.png)

**After**

![screen shot 2017-10-13 at 15 34 12](https://user-images.githubusercontent.com/1155574/31548710-0a8fe3da-b02c-11e7-92bb-d9f312cc4a60.png)
