### PR TITLE
Bump react-highlight-words version to fix React deprecation warnings

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cw-components",
-  "version": "2.7.6",
+  "version": "2.7.7",
   "description": "CoverWallet components",
   "main": "./build/lib/index.js",
   "repository": {
@@ -77,7 +77,7 @@
     "classnames": "^2.2.3",
     "lodash": "^4.15.0",
     "prop-types": "^15.5.8",
-    "react-highlight-words": "^0.3.0",
+    "react-highlight-words": "^0.9.0",
     "smoothscroll": "^0.2.2"
   }
 }


### PR DESCRIPTION
### Where

* **Pivotal Story:** https://www.pivotaltracker.com/story/show/151594342

### What

As a Dev I should not see any deprecation warning

### How

Bump react-highlight-words version

### Screenshots

![image](https://user-images.githubusercontent.com/28709273/32003887-29fb61aa-b9a9-11e7-8d36-3461b66220b7.png)
