### PR TITLE
Add multi-select component

### DIFF
--- a/examples/basic/app.js
+++ b/examples/basic/app.js
@@ -11,6 +11,7 @@ import {
   Loader,
   OnlyClickListOptions,
   OnlyClickSelect,
+  OnlyClickMultiSelect,
   CwFlashNotification,
   Checkbox,
   RadioInputGroup,
@@ -378,6 +379,22 @@ const App = function App() {
         <div>
           <OnlyClickSelect
             placeholder="Search industry subcategory"
+            hint="Select your industry subcategory"
+            options={industries[0].subindustries.map(subindustry => objectAssign({},
+              subindustry,
+              { label: subindustry.name, value: subindustry.name }
+            ))}
+            onClick={(value) => console.log('You choose ', value)}
+            onDelete={(value) => console.log('You remove ', value)}
+            values={[industries[0].subindustries[0].name]}
+          />
+        </div>
+
+        <h4>MultiSelect List view</h4>
+
+        <div>
+          <OnlyClickMultiSelect
+            errorMessage="Required"
             hint="Select your industry subcategory"
             options={industries[0].subindustries.map(subindustry => objectAssign({},
               subindustry,

--- a/lib/components/OnlyClickListOption.jsx
+++ b/lib/components/OnlyClickListOption.jsx
@@ -4,7 +4,7 @@ import classNames from 'classnames';
 import Highlighter from 'react-highlight-words';
 import { isIOS } from '../utils/deviceDetector';
 
-function OnlyClickListOption({ value, label, addition, checked, typedValue, highlight, onClick }) {
+function OnlyClickListOption({ value, label, addition, checked, typedValue, highlight, listType, onClick }) {
   const optionClass = classNames(
     'oc-options-list__item oc-list-option',
     { 'oc-list-option--checked': checked },
@@ -14,11 +14,16 @@ function OnlyClickListOption({ value, label, addition, checked, typedValue, high
   const messageClass = classNames(
     'oc-option__message'
   );
+  const multiSelectIconClass = classNames(
+    'oc-option__checked-icon',
+    { 'oc-option__checked-icon--checked': checked },
+  );
   return (
     <li
       className={optionClass}
       onClick={() => onClick(value)}
     >
+      {listType === 'multiSelect' && <span className={multiSelectIconClass} />}
       <span className={messageClass}>
         {highlight ?
           <Highlighter
@@ -32,7 +37,7 @@ function OnlyClickListOption({ value, label, addition, checked, typedValue, high
           {addition}
         </div>}
       </span>
-      <span className="oc-option__next-icon" />
+      {listType !== 'multiSelect' && <span className="oc-option__next-icon" />}
     </li>
   );
 }
@@ -44,6 +49,7 @@ OnlyClickListOption.propTypes = {
   typedValue: PropTypes.string,
   checked: PropTypes.bool,
   highlight: PropTypes.bool,
+  listType: PropTypes.string,
   onClick: PropTypes.func,
 };
 

--- a/lib/components/OnlyClickListOptions.jsx
+++ b/lib/components/OnlyClickListOptions.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import OnlyClickOption from './OnlyClickListOption';
 
 function OnlyClickListOptions(props) {
-  const { options, selectedValues, typedValue, highlight, onClick } = props;
+  const { options, selectedValues, typedValue, highlight, listType, onClick } = props;
   return (
     <ul className="oc-list-options">
       {options.map((option, i) => (
@@ -12,6 +12,7 @@ function OnlyClickListOptions(props) {
           checked={selectedValues.indexOf(option.value) !== -1}
           typedValue={typedValue}
           highlight={highlight}
+          listType={listType}
           onClick={onClick}
           {...option}
         />
@@ -26,6 +27,7 @@ OnlyClickListOptions.propTypes = {
   selectedValues: PropTypes.arrayOf(PropTypes.string),
   typedValue: PropTypes.string,
   highlight: PropTypes.bool,
+  listType: PropTypes.string,
 };
 
 export default OnlyClickListOptions;

--- a/lib/components/OnlyClickMultiSelect.jsx
+++ b/lib/components/OnlyClickMultiSelect.jsx
@@ -1,0 +1,83 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import OnlyClickOptionsList from './OnlyClickListOptions';
+
+class OnlyClickMultiSelect extends React.Component {
+  constructor(props) {
+    super(props);
+    this.mobileWidth = 480;
+    this.state = {
+      values: props.values,
+    };
+  }
+
+  componentWillReceiveProps(nextProps) {
+    const nextState = { values: nextProps.values };
+    this.setState(nextState);
+  }
+
+  propsChanged(nextProps) {
+    return (
+      this.props.values.length !== nextProps.values.length ||
+      this.props.options.length !== nextProps.options.length
+    );
+  }
+
+  handleClick = (value) => {
+    const { values } = this.state;
+    if (values.indexOf(value) === -1) {
+      this.setState({ values: [...values, value] });
+      if (this.props.onClick) {
+        this.props.onClick(value);
+      }
+    } else {
+      this.handleDelete(value);
+    }
+  };
+
+  handleDelete(value) {
+    const { values } = this.state;
+    if (values.indexOf(value) !== -1) {
+      this.setState({
+        values: values.filter(val => value !== val),
+      });
+    }
+    if (this.props.onDelete) {
+      this.props.onDelete(value);
+    }
+  }
+
+  render() {
+    const { options, hint, errorMessage } = this.props;
+    const { values } = this.state;
+    return (
+      <div className="oc-multi-select">
+        {hint && <div className="oc-multi-select__hint">{hint}</div>}
+        {errorMessage && <div className="oc-multi-select__error">{errorMessage}</div>}
+        <div className="oc-multi-select__options-container">
+          <OnlyClickOptionsList
+            listType="multiSelect"
+            options={options}
+            selectedValues={values}
+            onClick={this.handleClick}
+          />
+        </div>
+      </div>
+    );
+  }
+}
+
+OnlyClickMultiSelect.propTypes = {
+  hint: PropTypes.string,
+  errorMessage: PropTypes.string,
+  options: PropTypes.arrayOf(PropTypes.object).isRequired,
+  values: PropTypes.arrayOf(PropTypes.string),
+  onClick: PropTypes.func,
+  onDelete: PropTypes.func,
+};
+
+OnlyClickMultiSelect.defaultProps = {
+  values: [],
+};
+
+export default OnlyClickMultiSelect;

--- a/lib/components/OnlyClickMultiSelect.jsx
+++ b/lib/components/OnlyClickMultiSelect.jsx
@@ -5,7 +5,6 @@ import OnlyClickOptionsList from './OnlyClickListOptions';
 class OnlyClickMultiSelect extends React.Component {
   constructor(props) {
     super(props);
-    this.mobileWidth = 480;
     this.state = {
       values: props.values,
     };

--- a/lib/index.js
+++ b/lib/index.js
@@ -11,6 +11,7 @@ import OnlyClickListOptions from './components/OnlyClickListOptions';
 import OnlyClickIconOption from './components/OnlyClickIconOption';
 import OnlyClickIconOptions from './components/OnlyClickIconOptions';
 import OnlyClickSelect from './components/OnlyClickSelect';
+import OnlyClickMultiSelect from './components/OnlyClickMultiSelect';
 import CwFlashNotification from './components/CwFlashNotification';
 import Checkbox from './components/Checkbox';
 import RadioInput from './components/RadioInput';
@@ -25,6 +26,7 @@ export {
   IconRadioGroup,
   IconRadioInput,
   OnlyClickSelect,
+  OnlyClickMultiSelect,
   HighLightedText,
   OnlyClickListOption,
   OnlyClickListOptions,

--- a/lib/stylesheets/components/_components.scss
+++ b/lib/stylesheets/components/_components.scss
@@ -10,5 +10,6 @@
 @import 'oc_icon_options';
 @import 'oc_selected_value';
 @import 'oc_select';
+@import 'oc_multi_select';
 @import 'cw_flash_notification';
 @import 'common';

--- a/lib/stylesheets/components/_oc_list_option.scss
+++ b/lib/stylesheets/components/_oc_list_option.scss
@@ -73,6 +73,27 @@
     }
   }
 
+  .oc-option__checked-icon {
+    display: table-cell;
+    width: 30px;
+    @include cw-icon-before(circle-thin, 0px, $cwColor-black-light);
+
+    &::before, &.oc-option__checked-icon--checked:before {
+      font-size: 18px;
+      line-height: 20px;
+    }
+
+    &.oc-option__checked-icon--checked {
+      @include cw-icon-before(check-circle, 0px, $cwColor-base-white);
+
+      &:hover {
+        &:before {
+          color: $cwColor-base-white;
+        }
+      }
+    }
+  }
+
   .oc-option__search-term {
     font-weight: bold;
     background: transparent;

--- a/lib/stylesheets/components/_oc_multi_select.scss
+++ b/lib/stylesheets/components/_oc_multi_select.scss
@@ -1,0 +1,20 @@
+.oc-multi-select {
+  .oc-list-options {
+    margin-top: 0;
+    border-width: 1px 1px 0 0;
+  }
+
+  .oc-multi-select__hint {
+    @include clearfix();
+    padding: 10px 1px 10px;
+    font-size: 14px;
+    line-height: 16px;
+    color: $cwColor-black-xmedium;
+  }
+
+  .oc-multi-select__error {
+    margin: 7px 0;
+    color: $cwColor-base-red;
+    font-size: 14px;
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cw-components",
-  "version": "2.7.10",
+  "version": "2.7.11",
   "description": "CoverWallet components",
   "main": "./build/lib/index.js",
   "repository": {


### PR DESCRIPTION
### Where
* **Pivotal Story:** https://www.pivotaltracker.com/n/projects/2105824/stories/152349082
* **Rollbar Errors:** No.
* **Related PRs:** No.

### What
Add a new field that permits multi-selection of different options. Create a variation of an existing one called Normal List view in our cw-components library http://coverwallet.github.io/cw-components/basic/

### How
Added a new component OnlyClickMultiSelect. Reused components OnlyClickListOptions and OnlyClickListOption and added there a flag listType. For "multiSelect" listType set a new design according the requirements: 
- Remove the icon from the right side >.
- Add new icon at the left side with two states, checked and unchecked.
- Permit multi-select of options. 

### Screenshots
![image](https://user-images.githubusercontent.com/33116965/32216614-8f8d6b4e-be36-11e7-842a-fa8a73d32b79.png)


### Test
Check "MultiSelect List view" http://coverwallet.github.io/cw-components/basic/

### Deployment
As usual.

### Warnings
None.
