### PR TITLE
Add tooltip for multi-select component

### DIFF
--- a/examples/basic/app.js
+++ b/examples/basic/app.js
@@ -398,10 +398,15 @@ const App = function App() {
             hint="Select your industry subcategory"
             options={industries[0].subindustries.map(subindustry => objectAssign({},
               subindustry,
-              { label: subindustry.name, value: subindustry.name }
+              {
+                label: subindustry.name,
+                value: subindustry.name,
+                tooltipKey: subindustry.tooltip_key,
+              }
             ))}
             onClick={(value) => console.log('You choose ', value)}
             onDelete={(value) => console.log('You remove ', value)}
+            onHelpIconClick={(key) => console.log('Some help info for: ', key)}
             values={[industries[0].subindustries[0].name]}
           />
         </div>

--- a/examples/basic/catalog_api_json/industries.js
+++ b/examples/basic/catalog_api_json/industries.js
@@ -7,10 +7,12 @@ export default [
     "subindustries": [
       {
         "name": "All Other Business Support Services",
+        'tooltip_key': 1,
         "slug": "all-other-business-support-services"
       },
       {
         "name": "All Other Miscellaneous Waste Management Services",
+        'tooltip_key': 2,
         "slug": "all-other-miscellaneous-waste-management-services"
       },
       {

--- a/examples/basic/catalog_api_json/industries.js
+++ b/examples/basic/catalog_api_json/industries.js
@@ -7,12 +7,12 @@ export default [
     "subindustries": [
       {
         "name": "All Other Business Support Services",
-        'tooltip_key': 1,
+        "tooltip_key": "all-other-business-support-services",
         "slug": "all-other-business-support-services"
       },
       {
         "name": "All Other Miscellaneous Waste Management Services",
-        'tooltip_key': 2,
+        "tooltip_key": "all-other-miscellaneous-waste-management-services",
         "slug": "all-other-miscellaneous-waste-management-services"
       },
       {

--- a/lib/components/OnlyClickListOption.jsx
+++ b/lib/components/OnlyClickListOption.jsx
@@ -4,7 +4,7 @@ import classNames from 'classnames';
 import Highlighter from 'react-highlight-words';
 import { isIOS } from '../utils/deviceDetector';
 
-function OnlyClickListOption({ value, label, addition, checked, typedValue, highlight, listType, onClick }) {
+function OnlyClickListOption({ value, label, addition, checked, tooltipKey, typedValue, highlight, listType, onClick, onHelpClick }) {
   const optionClass = classNames(
     'oc-options-list__item oc-list-option',
     { 'oc-list-option--checked': checked },
@@ -17,6 +17,10 @@ function OnlyClickListOption({ value, label, addition, checked, typedValue, high
   const multiSelectIconClass = classNames(
     'oc-option__checked-icon',
     { 'oc-option__checked-icon--checked': checked },
+  );
+  const tooltipIconClass = classNames(
+    'oc-option__help-icon',
+    { 'oc-option__help-icon--checked': checked },
   );
   return (
     <li
@@ -37,6 +41,14 @@ function OnlyClickListOption({ value, label, addition, checked, typedValue, high
           {addition}
         </div>}
       </span>
+      {tooltipKey && (
+        <span
+          className={tooltipIconClass}
+          id={tooltipKey}
+          onClick={onHelpClick && onHelpClick.bind(null, tooltipKey)}
+          tabIndex="-1"
+        />
+      )}
       {listType !== 'multiSelect' && <span className="oc-option__next-icon" />}
     </li>
   );
@@ -46,11 +58,13 @@ OnlyClickListOption.propTypes = {
   value: PropTypes.string.isRequired,
   label: PropTypes.string.isRequired,
   addition: PropTypes.string,
+  tooltipKey: PropTypes.string,
   typedValue: PropTypes.string,
   checked: PropTypes.bool,
   highlight: PropTypes.bool,
   listType: PropTypes.string,
   onClick: PropTypes.func,
+  onHelpClick: PropTypes.func,
 };
 
 export default OnlyClickListOption;

--- a/lib/components/OnlyClickListOption.jsx
+++ b/lib/components/OnlyClickListOption.jsx
@@ -58,7 +58,10 @@ OnlyClickListOption.propTypes = {
   value: PropTypes.string.isRequired,
   label: PropTypes.string.isRequired,
   addition: PropTypes.string,
-  tooltipKey: PropTypes.string,
+  tooltipKey: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.number,
+  ]),
   typedValue: PropTypes.string,
   checked: PropTypes.bool,
   highlight: PropTypes.bool,

--- a/lib/components/OnlyClickListOptions.jsx
+++ b/lib/components/OnlyClickListOptions.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import OnlyClickOption from './OnlyClickListOption';
 
 function OnlyClickListOptions(props) {
-  const { options, selectedValues, typedValue, highlight, listType, onClick } = props;
+  const { options, selectedValues, typedValue, highlight, listType, onClick, onHelpClick } = props;
   return (
     <ul className="oc-list-options">
       {options.map((option, i) => (
@@ -14,6 +14,7 @@ function OnlyClickListOptions(props) {
           highlight={highlight}
           listType={listType}
           onClick={onClick}
+          onHelpClick={onHelpClick}
           {...option}
         />
       ))}
@@ -24,6 +25,7 @@ function OnlyClickListOptions(props) {
 OnlyClickListOptions.propTypes = {
   options: PropTypes.arrayOf(PropTypes.object),
   onClick: PropTypes.func,
+  onHelpClick: PropTypes.func,
   selectedValues: PropTypes.arrayOf(PropTypes.string),
   typedValue: PropTypes.string,
   highlight: PropTypes.bool,

--- a/lib/components/OnlyClickMultiSelect.jsx
+++ b/lib/components/OnlyClickMultiSelect.jsx
@@ -47,7 +47,7 @@ class OnlyClickMultiSelect extends React.Component {
   }
 
   render() {
-    const { options, hint, errorMessage } = this.props;
+    const { options, hint, errorMessage, onHelpIconClick } = this.props;
     const { values } = this.state;
     return (
       <div className="oc-multi-select">
@@ -59,6 +59,7 @@ class OnlyClickMultiSelect extends React.Component {
             options={options}
             selectedValues={values}
             onClick={this.handleClick}
+            onHelpClick={onHelpIconClick}
           />
         </div>
       </div>
@@ -73,6 +74,7 @@ OnlyClickMultiSelect.propTypes = {
   values: PropTypes.arrayOf(PropTypes.string),
   onClick: PropTypes.func,
   onDelete: PropTypes.func,
+  onHelpIconClick: PropTypes.func,
 };
 
 OnlyClickMultiSelect.defaultProps = {

--- a/lib/stylesheets/components/_oc_list_option.scss
+++ b/lib/stylesheets/components/_oc_list_option.scss
@@ -73,6 +73,21 @@
     }
   }
 
+  .oc-option__help-icon {
+    display: table-cell;
+    width: 20px;
+    @include cw-icon-before(question-circle, 0, $cwColor-base-blue);
+
+    &::before, &.oc-option__help-icon--checked:before {
+      font-size: 18px;
+      line-height: 20px;
+    }
+
+    &.oc-option__help-icon--checked:before {
+      color: $cwColor-base-white;
+    }
+  }
+
   .oc-option__checked-icon {
     display: table-cell;
     width: 30px;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cw-components",
-  "version": "2.7.11",
+  "version": "2.7.12",
   "description": "CoverWallet components",
   "main": "./build/lib/index.js",
   "repository": {


### PR DESCRIPTION
### Where
* **Pivotal Story:** https://www.pivotaltracker.com/n/projects/2105824/stories/152349082
* **Rollbar Errors:** No
* **Related PRs:** No

### What
Add a tooltip in options for multi-select component. Dzmitry provided a link https://projects.invisionapp.com/share/M8E4SN665#/screens/261276881

### How
Added a help-icon for options which has tooltipKey in OnlyClickListOption component.

### Screenshots
![image](https://user-images.githubusercontent.com/33116965/32367595-45b1491c-c08b-11e7-9c86-27cd60d9e28d.png)

### Test
Check "MultiSelect List view" http://coverwallet.github.io/cw-components/basic/

### Deployment
As usual.

### Warnings
None.
