### PR TITLE
OnlyClickIconOptions: add ability to highlight recommendable options

### DIFF
--- a/examples/basic/app.js
+++ b/examples/basic/app.js
@@ -432,7 +432,7 @@ const App = function App() {
           />
         </div>
 
-        <h4>With help icon</h4>
+        <h4>With help icon and recommendable options</h4>
 
         <div>
           <OnlyClickSelect
@@ -445,6 +445,7 @@ const App = function App() {
                 value: type.name,
                 iconClass: type.icon_name,
                 tooltipKey: type.tooltip_key,
+                recommendable: type.recommendable,
               },
             ))}
             onClick={(value) => console.log('You choose ', value)}

--- a/examples/basic/catalog_api_json/insuranceTypes.js
+++ b/examples/basic/catalog_api_json/insuranceTypes.js
@@ -8,7 +8,8 @@ export default [
     "tooltip_key": "insurance_type_business_owners_policy_(bop)",
     "display_order": 1,
     "icon_name": "business_owners_policy_bop",
-    "formatted_text": null
+    "formatted_text": null,
+    "recommendable": true
   },
   {
     "name": "General Liability",
@@ -19,7 +20,8 @@ export default [
     "tooltip_key": "insurance_type_general_liability",
     "display_order": 2,
     "icon_name": "general_liability",
-    "formatted_text": null
+    "formatted_text": null,
+    "recommendable": true
   },
   {
     "name": "Commercial Building and/or Property",
@@ -41,7 +43,8 @@ export default [
     "tooltip_key": "insurance_type_workers_compensation",
     "display_order": 4,
     "icon_name": "workers_compensation",
-    "formatted_text": null
+    "formatted_text": null,
+    "recommendable": true
   },
   {
     "name": "Disability Insurance",

--- a/lib/components/OnlyClickIconOption.jsx
+++ b/lib/components/OnlyClickIconOption.jsx
@@ -4,10 +4,11 @@ import classNames from 'classnames';
 import { isIOS } from '../utils/deviceDetector';
 
 function OnlyClickIconOption(props) {
-  const { value, label, checked, iconClass, onClick } = props;
+  const { value, label, checked, recommendable, iconClass, onClick } = props;
   const optionClass = classNames(
     'oc-icon-option',
     { 'oc-icon-option--checked': checked },
+    { 'oc-icon-option--recommendable': recommendable },
     { 'oc-icon-option--no-touch': !isIOS() }
   );
   return (
@@ -30,6 +31,7 @@ OnlyClickIconOption.propTypes = {
   value: PropTypes.string.isRequired,
   label: PropTypes.string.isRequired,
   checked: PropTypes.bool,
+  recommendable: PropTypes.bool,
   iconClass: PropTypes.string,
   onClick: PropTypes.func,
 };

--- a/lib/stylesheets/components/_oc_icon_option.scss
+++ b/lib/stylesheets/components/_oc_icon_option.scss
@@ -47,12 +47,48 @@
       color: $cwColor-base-white;
     }
   }
+
+  &--recommendable {
+    position: relative;
+    @include cw-icon-before(star, 0, $cwColor-base-white);
+
+    &::before {
+      position: absolute;
+      font-size: 12px;
+      top: 2px;
+      left: 2px;
+      z-index: 2;
+    }
+
+    &::after {
+      position: absolute;
+      content: '';
+      width: 0;
+      height: 0;
+      top: -1px;
+      left: -1px;
+      border-top: 30px solid $cwColor-base-orange;
+      border-right: 30px solid $cwColor-base-white;
+      border-top-left-radius: 5px;
+      z-index: 1;
+    }
+
+    &:hover::after {
+      border-right-color: $cwColor-blue-light;
+    }
+  }
+
   &--checked {
     color: $cwColor-base-white;
     background-color: $cwColor-base-blue;
     .oc-icon-option__icon::before {
       color: $cwColor-base-white;
     }
+
+    &.oc-icon-option--recommendable::after {
+      border-right-color: $cwColor-base-blue;
+    }
+
     &:hover {
       color: $cwColor-base-white;
       background-color: $cwColor-base-blue;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cw-components",
-  "version": "2.7.13",
+  "version": "2.7.14",
   "description": "CoverWallet components",
   "main": "./build/lib/index.js",
   "repository": {


### PR DESCRIPTION
### Where
* **Pivotal Story:** https://www.pivotaltracker.com/n/projects/2037291/stories/153097906

### What
Add ability to highlight some insurance products in the insurance type page.

### How
Added property 'recommendable' for the OnlyClickIconOption component, styles and an example

### Screenshots
![image](https://user-images.githubusercontent.com/33116965/33428730-1470621a-d5db-11e7-9c84-b7c9f5a29c7a.png)