### PR TITLE
Add ability to pass sanitizer function to typeahead's highlight

### DIFF
--- a/lib/components/OnlyClickListOption.jsx
+++ b/lib/components/OnlyClickListOption.jsx
@@ -13,6 +13,7 @@ function OnlyClickListOption({
   tooltipKey,
   typedValue,
   highlight,
+  highlightSanitizer,
   listType,
   onClick,
   onHelpClick,
@@ -33,7 +34,12 @@ function OnlyClickListOption({
       {listType === 'multiSelect' && <span className={multiSelectIconClass} />}
       <span className={messageClass}>
         {highlight ? (
-          <Highlighter highlightClassName={'oc-option__search-term'} searchWords={typedValue.trim().split(' ')} textToHighlight={label} />
+          <Highlighter
+            highlightClassName={'oc-option__search-term'}
+            searchWords={typedValue.trim().split(' ')}
+            textToHighlight={label}
+            sanitize={highlightSanitizer}
+          />
         ) : (
           label
         )}
@@ -57,6 +63,7 @@ OnlyClickListOption.propTypes = {
   checked: PropTypes.bool,
   disabled: PropTypes.bool,
   highlight: PropTypes.bool,
+  highlightSanitizer: PropTypes.func,
   listType: PropTypes.string,
   onClick: PropTypes.func,
   onHelpClick: PropTypes.func,

--- a/lib/components/OnlyClickListOptions.jsx
+++ b/lib/components/OnlyClickListOptions.jsx
@@ -4,7 +4,17 @@ import OnlyClickOption from './OnlyClickListOption';
 import classNames from 'classnames';
 
 function OnlyClickListOptions(props) {
-  const { options, selectedValues, typedValue, highlight, listType, onClick, onHelpClick, disabled } = props;
+  const {
+    options,
+    selectedValues,
+    typedValue,
+    highlight,
+    highlightSanitizer,
+    listType,
+    onClick,
+    onHelpClick,
+    disabled,
+  } = props;
 
   return (
     <ul
@@ -18,6 +28,7 @@ function OnlyClickListOptions(props) {
           checked={selectedValues.indexOf(option.value) !== -1}
           typedValue={typedValue}
           highlight={highlight}
+          highlightSanitizer={highlightSanitizer}
           listType={listType}
           onClick={onClick}
           onHelpClick={onHelpClick}
@@ -36,7 +47,9 @@ OnlyClickListOptions.propTypes = {
   selectedValues: PropTypes.arrayOf(PropTypes.string),
   typedValue: PropTypes.string,
   highlight: PropTypes.bool,
+  highlightSanitizer: PropTypes.func,
   listType: PropTypes.string,
+  disabled: PropTypes.bool,
 };
 
 export default OnlyClickListOptions;

--- a/lib/components/OnlyClickSelect.jsx
+++ b/lib/components/OnlyClickSelect.jsx
@@ -111,8 +111,8 @@ class OnlyClickSelect extends React.Component {
   render() {
     const {
       type, options, placeholder, hint, errorMessage,
-      highlight, maxVisible, onHelpIconClick,
-      disableFilter, disableInput, disableDelete
+      highlight, highlightSanitizer, maxVisible, onHelpIconClick,
+      disableFilter, disableInput, disableDelete,
     } = this.props;
     const { values, typedValue } = this.state;
     const filteredOptions = disableFilter
@@ -160,6 +160,7 @@ class OnlyClickSelect extends React.Component {
               onClick={this.handleClick}
               typedValue={typedValue}
               highlight={highlight}
+              highlightSanitizer={highlightSanitizer}
             />
           }
         </div>
@@ -185,6 +186,7 @@ OnlyClickSelect.propTypes = {
   disableDelete: PropTypes.bool,
   autoFocus: PropTypes.bool,
   highlight: PropTypes.bool,
+  highlightSanitizer: PropTypes.func,
   disableInput: PropTypes.bool,
   autoScroll: PropTypes.bool,
   scrollTop: PropTypes.number,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cw-components",
-  "version": "2.8.0",
+  "version": "2.8.1",
   "description": "CoverWallet components",
   "main": "./build/lib/index.js",
   "repository": {


### PR DESCRIPTION
### Where

* **Pivotal Story:** https://coverwallet.atlassian.net/browse/ZUR-799

### What

As a user I want to be able to search for industries if I don't use accents or special characters

### How

Add ability to pass sanitizer function to typeahead's highlight

### Screenshots

![image](https://user-images.githubusercontent.com/28709273/36489952-3bc76054-1738-11e8-840b-8e1537fd9c51.png)

![image](https://user-images.githubusercontent.com/28709273/36490956-9e9c4792-173a-11e8-8b4b-c434ab26606f.png)
