### PR TITLE
Allow to set current year as default when plus or minus is clicked

### DIFF
--- a/lib/components/NumberInput.jsx
+++ b/lib/components/NumberInput.jsx
@@ -59,15 +59,21 @@ class NumberInput extends React.Component {
     } else {
       this.setNextValue(nextValue);
     }
+    if (this.props.onPlus) {
+      this.props.onPlus(this.state.value, number);
+    }
   };
 
   handleMinus = () => {
     const number = parseInt(String(this.refs.input.value).replace(/[,%]/g, ''), 10) || 0;
     const step = this.props.step ? this.props.step : 1;
     const min = this.props.min ? this.props.min : 0;
+    const nextValue = number - step;
     if ((number - step) >= min) {
-      const nextValue = number - step;
       this.setNextValue(nextValue);
+    }
+    if (this.props.onMinus) {
+      this.props.onMinus(this.state.value, number);
     }
   };
 
@@ -115,6 +121,8 @@ NumberInput.propTypes = {
   type: PropTypes.string,
   min: PropTypes.number,
   max: PropTypes.number,
+  onMinus: PropTypes.func,
+  onPlus: PropTypes.func,
   step: PropTypes.number,
   currency: PropTypes.bool,
   currencyType: PropTypes.string,


### PR DESCRIPTION
### Where

* **Jira Story:** https://coverwallet.atlassian.net/browse/IN-322
* **Related PRs:** https://github.com/coverwallet/quotes-frontend/pull/1451
### What

Allow start from current year when user clicks on plus or minus on Business start year input

### How

Adding onMinus and onPlus props to allow pass functions to detect this case and set currente year instead default number.

### Test

Go to "Tell us about your company" page in SHF and click plus or minus when input is empty. It should start with the current year
