### PR TITLE
Change version in order to npm allows to publish it

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cw-components",
-  "version": "2.8.2",
+  "version": "2.8.3",
   "description": "CoverWallet components",
   "main": "./build/lib/index.js",
   "repository": {


### PR DESCRIPTION
### What
npm doesn't publish the new version because this error: "You cannot publish over the previously published versions: 2.8.2". I guess this happens because the version isn't manually changed in the package.json.