### PR TITLE
Autocomplete input fields failure when informing the pipe character

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cw-components",
-  "version": "2.8.3",
+  "version": "2.8.4",
   "description": "CoverWallet components",
   "main": "./build/lib/index.js",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "classnames": "^2.2.3",
     "lodash": "^4.15.0",
     "prop-types": "^15.5.8",
-    "react-highlight-words": "^0.9.0",
+    "react-highlight-words": "^0.11.0",
     "smoothscroll": "^0.2.2"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2600,9 +2600,9 @@ he@1.1.x:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/he/-/he-1.1.1.tgz#93410fd21b009735151f8868c2f271f3427e23fd"
 
-highlight-words-core@^1.0.2:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/highlight-words-core/-/highlight-words-core-1.1.2.tgz#5c2717c4f6c6e7ea2462ab85b43ff8b24f58ec3e"
+highlight-words-core@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/highlight-words-core/-/highlight-words-core-1.2.0.tgz#232bec301cbf2a4943d335dc748ce70e9024f3b1"
 
 hoek@2.x.x:
   version "2.16.3"
@@ -4602,11 +4602,11 @@ react-dom@^15.4.2:
     object-assign "^4.1.0"
     prop-types "^15.5.10"
 
-react-highlight-words@^0.9.0:
-  version "0.9.0"
-  resolved "https://registry.yarnpkg.com/react-highlight-words/-/react-highlight-words-0.9.0.tgz#aea72a9f28637fc6a77bc2a99efa08e638af43d7"
+react-highlight-words@^0.11.0:
+  version "0.11.0"
+  resolved "https://registry.yarnpkg.com/react-highlight-words/-/react-highlight-words-0.11.0.tgz#4f3c2039a8fd275f3ab795e59946b0324d8e6bee"
   dependencies:
-    highlight-words-core "^1.0.2"
+    highlight-words-core "^1.2.0"
     prop-types "^15.5.8"
 
 react-test-renderer@^15.4.2:


### PR DESCRIPTION
### Where

* **JIRA Story:** https://coverwallet.atlassian.net/browse/ACQ-28

### What

The browser was freezing when the pipe character was typed in the input of the OnlyClickSelect in the InsurancePage. In the end, the bug was in the react-hightlight-words library: https://github.com/bvaughn/react-highlight-words/issues/42 

### How
 
Updating react-hightlight-words lib.

