### PR TITLE
Fix version number because npm doesn't publish 2.8.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cw-components",
-  "version": "2.8.5",
+  "version": "2.8.6",
   "description": "CoverWallet components",
   "main": "./build/lib/index.js",
   "repository": {


### PR DESCRIPTION
### Where

* **JIRA Story:** https://coverwallet.atlassian.net/browse/ACQ-160
* **Related PRs:** https://github.com/coverwallet/cw-components/pull/120

### What

Change again version number because npm doesn't publish 2.8.5
