### PR TITLE
Make texts with 2 lines being more adjusted

### DIFF
--- a/lib/stylesheets/components/_icons_radio_group.scss
+++ b/lib/stylesheets/components/_icons_radio_group.scss
@@ -45,6 +45,7 @@
   }
 
   .icons-radio-input__icon {
+    font-family: 'coverwallet-general';
     font-size: 25px;
     padding-top: 7px;
     line-height: 25px;
@@ -68,6 +69,7 @@
     margin-top: 4px;
     color: $cwColor-black-dark;
     font-size: 11px;
+    line-height: 12px;
 
     @include media($mobile) {
       font-size: 10px;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cw-components",
-  "version": "2.9.1",
+  "version": "2.9.2",
   "description": "CoverWallet components",
   "main": "./build/lib/index.js",
   "repository": {


### PR DESCRIPTION
### Where

* **JIRA Story:** https://coverwallet.atlassian.net/browse/ACQ-160 (this is a fix related with this story, I need to do this in order to finish what the user story says)

### What

Fix icon radio group text when its label has 2 lines instead of one. This can be understood better with images (look at the screenshots). @marlex knows about this and she has helped me to fix it.

### Screenshots
Before:
![image](https://user-images.githubusercontent.com/6703511/46728282-bfc56680-cc82-11e8-9b5f-962ad318102d.png)

After:
![image](https://user-images.githubusercontent.com/6703511/46728313-d2d83680-cc82-11e8-82ab-80510b5bf119.png)
