### PR TITLE
ZUR-1819 - Fix missaligned tooltip icon on OnlyClickListOption

### DIFF
--- a/lib/components/OnlyClickListOption.jsx
+++ b/lib/components/OnlyClickListOption.jsx
@@ -40,7 +40,7 @@ function OnlyClickListOption(props) {
       {optionComponent ? (
         <span>{optionComponent(props)}</span>
       ) : (
-        <span>
+        <span className="oc-list-option__container">
           {listType === 'multiSelect' && <span className={multiSelectIconClass} />}
           <span className={messageClass}>
             {highlight ? (

--- a/lib/stylesheets/components/_oc_list_option.scss
+++ b/lib/stylesheets/components/_oc_list_option.scss
@@ -55,6 +55,11 @@
     }
   }
 
+  &__container{
+    display: table;
+    width: 100%;
+  }
+
   &:focus:not(&--disabled),
   &:active:not(&--disabled),
   &--clicked:not(&--disabled) {


### PR DESCRIPTION
### Where

* **Pivotal Story:** https://coverwallet.atlassian.net/browse/ZUR-1819

### What

Due to changes made on refactoring, OnlyClickListOption component is broken now and shows tooltips misaligned.

### How

We have applied a class over the container to make this container to have `display: table`.

### Screenshots

![image 2](https://user-images.githubusercontent.com/10259582/47295079-1893e800-d60f-11e8-82a0-691ece10d12b.png)
