### PR TITLE
Add key event handler to OnlyClickSelect

### DIFF
--- a/examples/basic/app.js
+++ b/examples/basic/app.js
@@ -419,6 +419,7 @@ const App = function App() {
             ))}
             onClick={(value) => console.log('You choose ', value)}
             onDelete={(value) => console.log('You remove ', value)}
+            onEnterKeyPress={(value) => console.log('You pressed the Enter key')}
             autoFocus
           />
         </div>
@@ -435,6 +436,7 @@ const App = function App() {
             ))}
             onClick={(value) => console.log('You choose ', value)}
             onDelete={(value) => console.log('You remove ', value)}
+            onEnterKeyPress={(value) => console.log('You pressed the Enter key')}
             values={[industries[0].subindustries[0].name]}
           />
         </div>
@@ -473,6 +475,7 @@ const App = function App() {
             onChange={(value) => console.log('You typed ', value)}
             onClick={(value) => console.log('You choose ', value)}
             onDelete={(value) => console.log('You remove ', value)}
+            onEnterKeyPress={(value) => console.log('You pressed the Enter key')}
             values={[industries[0].subindustries[0].name]}
             maxVisible={10}
             disableFilter
@@ -499,6 +502,7 @@ const App = function App() {
             ))}
             onClick={(value) => console.log('You choose ', value)}
             onDelete={(value) => console.log('You remove ', value)}
+            onEnterKeyPress={(value) => console.log('You pressed the Enter key')}
             onHelpIconClick={(key) => console.log('Some help info for: ', key)}
           />
         </div>

--- a/lib/components/OnlyClickSelect.jsx
+++ b/lib/components/OnlyClickSelect.jsx
@@ -98,6 +98,15 @@ class OnlyClickSelect extends React.Component {
     }
   };
 
+  handleKeyPress = (e) => {
+    const { onEnterKeyPress } = this.props;
+
+    if (onEnterKeyPress && e.key === 'Enter') {
+      const { value } = e.target;
+      onEnterKeyPress(value);
+    }
+  };
+
   handleDelete(value) {
     const { values } = this.state;
     if (values.indexOf(value) !== -1) {
@@ -141,6 +150,7 @@ class OnlyClickSelect extends React.Component {
                 placeholder={placeholder}
                 value={typedValue}
                 onChange={this.handleChange}
+                onKeyPress={this.handleKeyPress}
                 disabled={disableInput}
               />
             </div>
@@ -184,6 +194,7 @@ OnlyClickSelect.propTypes = {
   onClick: PropTypes.func,
   onDelete: PropTypes.func,
   onHelpIconClick: PropTypes.func,
+  onEnterKeyPress: PropTypes.func,
   disableFilter: PropTypes.bool,
   disableDelete: PropTypes.bool,
   autoFocus: PropTypes.bool,

--- a/lib/components/__tests__/OnlyClickSelect.test.jsx
+++ b/lib/components/__tests__/OnlyClickSelect.test.jsx
@@ -1,0 +1,50 @@
+/* eslint no-use-before-define: 0 */
+import React from 'react';
+import { mount } from 'enzyme';
+
+import OnlyClickSelect from '../OnlyClickSelect';
+
+describe('OnlyClickSelect', () => {
+  describe('keypress event', () => {
+    beforeEach(() => {
+      jest.resetAllMocks();
+    });
+
+    it('calls onEnterKeyPress prop with the input value when Enter key is pressed', () => {
+      const keyword = 'text';
+      const component = renderComponent();
+      const input = component.find('.oc-select__input');
+      typeIn(component, input, keyword);
+      pressEnterKey(input);
+
+      expect(component.prop('onEnterKeyPress')).toHaveBeenCalledWith(keyword);
+    });
+
+    it('does NOT call onEnterKeyPress prop when pressing a key that is NOT the Enter key', () => {
+      const component = renderComponent();
+      const input = component.find('.oc-select__input');
+      input.simulate('keypress', { key: 'a' });
+
+      expect(component.prop('onEnterKeyPress')).not.toHaveBeenCalled();
+    });
+
+    const props = {
+      options: [
+        {
+          label: 'option',
+          value: 'option',
+        },
+      ],
+      onEnterKeyPress: jest.fn(),
+    };
+
+    const renderComponent = () => mount(<OnlyClickSelect {...props} />);
+
+    const typeIn = (component, input, text) => {
+      input.simulate('change', { target: { value: text } });
+      component.update();
+    };
+
+    const pressEnterKey = (input) => input.simulate('keypress', { key: 'Enter' });
+  });
+});


### PR DESCRIPTION
### Where

* **JIRA Story:** https://coverwallet.atlassian.net/browse/ACQ-522

### What

We need this in order to set a flag when the form is submitted pressing the `Enter` key. The usual behavior of the submit event is triggering the click event of the submit button of the form, that's why we can't use the `onClick` of the submit button. We can’t use the ` OnlyClickSelect `'s `onChange` prop either because this `onChange` is the React’s one, not the native one, so it is not triggered when the `Enter` key is pressed.

### How

Adding a new optional prop `onEnterKeyPress` which is called when the `keypress` event is triggered and the `key` pressed is the `Enter` key.

### Test

`yarn test lib/components/__tests__/OnlyClickSelect.test.jsx`
