### PR TITLE
OnlyClickListOptions - Fix selectedOptions error when not informed

### DIFF
--- a/lib/components/OnlyClickListOptions.jsx
+++ b/lib/components/OnlyClickListOptions.jsx
@@ -27,7 +27,7 @@ function OnlyClickListOptions(props) {
       {options.map((option, i) => (
         <OnlyClickOption
           key={option.value + i}
-          checked={selectedValues.indexOf(option.value) !== -1}
+          checked={selectedValues ? selectedValues.indexOf(option.value) !== -1 : false}
           typedValue={typedValue}
           highlight={highlight}
           highlightSanitizer={highlightSanitizer}

--- a/lib/components/__tests__/OnlyClickListOptions.test.jsx
+++ b/lib/components/__tests__/OnlyClickListOptions.test.jsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import { mount } from 'enzyme';
+
+import { OnlyClickListOptions } from '../../index';
+
+describe('OnlyClickListOptions', () => {
+  describe('selectedOptions', () => {
+    it('should be optional', () => {
+      const options = [{
+        value: 'Value',
+        label: 'Label',
+      }];
+      const wrapper = mount(<OnlyClickListOptions
+        options={options}
+      />);
+
+      expect(wrapper.props().options).toBe(options);
+    });
+  });
+});

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cw-components",
-  "version": "2.11.1",
+  "version": "2.11.2",
   "description": "CoverWallet components",
   "main": "./build/lib/index.js",
   "repository": {


### PR DESCRIPTION
### What

An error is thrown when no selectedOptions are passed as prop to OnlyClickListOptions component.

![image](https://user-images.githubusercontent.com/6910444/49018884-d9683200-f18c-11e8-871c-4221e8f3bbab.png)

### How

Adding fallback to avoid error when there is not selectedOptions prop.
