### PR TITLE
Radio group without icon

### DIFF
--- a/lib/components/IconRadioGroup.jsx
+++ b/lib/components/IconRadioGroup.jsx
@@ -47,7 +47,7 @@ class IconRadioGroup extends React.Component {
           {
             'icons-radio-group--disabled': disabled,
           },
-          { [className]: className },
+          className,
         )}
       >
         {options.map((option, i) => (

--- a/lib/components/IconRadioGroup.jsx
+++ b/lib/components/IconRadioGroup.jsx
@@ -39,12 +39,16 @@ class IconRadioGroup extends React.Component {
   };
 
   render() {
-    const { options, name, size, disabled } = this.props;
+    const { options, name, size, disabled, className } = this.props;
     return (
       <div
-        className={classNames('icons-radio-group', {
-          'icons-radio-group--disabled': disabled,
-        })}
+        className={classNames(
+          'icons-radio-group',
+          {
+            'icons-radio-group--disabled': disabled,
+          },
+          { [className]: className },
+        )}
       >
         {options.map((option, i) => (
           <IconRadioInput
@@ -72,6 +76,7 @@ IconRadioGroup.propTypes = {
   onChange: PropTypes.func,
   size: PropTypes.string,
   disabled: PropTypes.bool,
+  className: PropTypes.string,
 };
 
 export default IconRadioGroup;

--- a/lib/components/IconRadioInput.jsx
+++ b/lib/components/IconRadioInput.jsx
@@ -50,7 +50,7 @@ class IconRadioInput extends React.Component {
       { 'icons-radio-input--small': size === 'small' },
       { 'icons-radio-input--disabled': disabled },
       { 'icons-radio-input--no-icon': !iconClass },
-      { [className]: className },
+      className,
     );
     const inputId = `${name}${value}`;
     return (

--- a/lib/components/IconRadioInput.jsx
+++ b/lib/components/IconRadioInput.jsx
@@ -33,7 +33,15 @@ class IconRadioInput extends React.Component {
   }
 
   render() {
-    const { name, value, label, size, disabled } = this.props;
+    const {
+      name,
+      value,
+      label,
+      size,
+      disabled,
+      iconClass,
+      className,
+    } = this.props;
     const { checked } = this.state;
     const buttonClass = classNames(
       'icons-radio-input',
@@ -41,6 +49,8 @@ class IconRadioInput extends React.Component {
       { 'icons-radio-input--no-touch': !isIOS() },
       { 'icons-radio-input--small': size === 'small' },
       { 'icons-radio-input--disabled': disabled },
+      { 'icons-radio-input--no-icon': !iconClass },
+      { [className]: className },
     );
     const inputId = `${name}${value}`;
     return (
@@ -56,7 +66,13 @@ class IconRadioInput extends React.Component {
           checked={checked}
           disabled={disabled}
         />
-        <div className="icons-radio-input__label">{this.props.label}</div>
+        <div
+          className={classNames('icons-radio-input__label', {
+            'icons-radio-input__label--top-separation': iconClass,
+          })}
+        >
+          {label}
+        </div>
       </label>
     );
   }
@@ -71,6 +87,7 @@ IconRadioInput.propTypes = {
   onChange: PropTypes.func.isRequired,
   size: PropTypes.string,
   disabled: PropTypes.bool,
+  className: PropTypes.string,
 };
 
 export default IconRadioInput;

--- a/lib/stylesheets/components/_icons_radio_group.scss
+++ b/lib/stylesheets/components/_icons_radio_group.scss
@@ -114,4 +114,10 @@
     border: 1px solid $cwColor-black-light;
     background-color: $cwColor-black-mlight;
   }
+
+  &--no-icon {
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+  }
 }

--- a/lib/stylesheets/components/_icons_radio_group.scss
+++ b/lib/stylesheets/components/_icons_radio_group.scss
@@ -44,7 +44,7 @@
     margin: 1%;
   }
 
-  .icons-radio-input__icon {
+  &__icon {
     font-family: 'coverwallet-general';
     font-size: 25px;
     padding-top: 7px;
@@ -61,18 +61,21 @@
     }
   }
 
-  .icons-radio-input__input {
+  &__input {
     display: none;
   }
 
-  .icons-radio-input__label {
-    margin-top: 4px;
+  &__label {
     color: $cwColor-black-dark;
     font-size: 11px;
     line-height: 12px;
 
     @include media($mobile) {
       font-size: 10px;
+    }
+
+    &--top-separation {
+      margin-top: 4px;
     }
   }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cw-components",
-  "version": "2.11.4",
+  "version": "2.12.0",
   "description": "CoverWallet components",
   "main": "./build/lib/index.js",
   "repository": {


### PR DESCRIPTION
### What

Enabling select options without icon.

### How

- Using no-icon modifier.

In addition to that we also did:
- Remove 2 level selectors.
- Add className properties to both components.
- Remove margin/padding top when there is no icon (so that is centred vertically)

### Screenshots

Previous:
![image](https://user-images.githubusercontent.com/17853818/49453563-ad2f5f80-f7e3-11e8-8fce-1af63183bab4.png)

Actual:
![image](https://user-images.githubusercontent.com/17853818/49453553-a6a0e800-f7e3-11e8-8017-331929c1ffba.png)

### Warnings

Would have loved to change component name to selectBoxComponent or something similar since it will not need icons anymore, but that would mean a mayor release.