### PR TITLE
Add open and close tooltip callbacks to ButtonsListSelect

### DIFF
--- a/examples/basic/app.js
+++ b/examples/basic/app.js
@@ -527,7 +527,8 @@ const App = function App() {
           ))}
           onSelect={(value) => console.log('You select ', value)}
           onDeselect={(value) => console.log('You deselect ', value)}
-          onClickHelp={(value) => console.log('Clicked help of ', value)}
+          onOpenHelp={(value) => console.log('Opened help of ', value)}
+          onCloseHelp={(value) => console.log('Closed help of ', value)}
           selectedOptions={['Business Owners Policy (BOP)']}
           accordion
           errorMessage="If errorMessage prop is present, it will be displayed here"

--- a/lib/components/ButtonsListSelect.jsx
+++ b/lib/components/ButtonsListSelect.jsx
@@ -64,7 +64,7 @@ class ButtonsListSelect extends Component {
   }
 
   render() {
-    const { onClickHelp, selectedOptions, accordion, errorMessage } = this.props;
+    const { onOpenHelp, selectedOptions, accordion, errorMessage } = this.props;
     const { isViewMoreRendered, itemsToShow } = this.state;
     const optionsToRender = this.getOptionsToRender(itemsToShow, isViewMoreRendered);
 
@@ -75,7 +75,7 @@ class ButtonsListSelect extends Component {
           options={optionsToRender}
           selectedOptions={selectedOptions}
           onClick={this.handleClick}
-          onClickHelp={onClickHelp}
+          onOpenHelp={onOpenHelp}
           accordion={accordion}
         />
         {isViewMoreRendered &&
@@ -93,7 +93,7 @@ ButtonsListSelect.propTypes = {
   selectedOptions: PropTypes.arrayOf(PropTypes.string),
   onSelect: PropTypes.func.isRequired,
   onDeselect: PropTypes.func.isRequired,
-  onClickHelp: PropTypes.func,
+  onOpenHelp: PropTypes.func,
   isViewMoreEnabled: PropTypes.bool,
   itemsToShowFirstRender: PropTypes.number,
   itemsPerPage: PropTypes.number,

--- a/lib/components/ButtonsListSelect.jsx
+++ b/lib/components/ButtonsListSelect.jsx
@@ -64,7 +64,7 @@ class ButtonsListSelect extends Component {
   }
 
   render() {
-    const { onOpenHelp, selectedOptions, accordion, errorMessage } = this.props;
+    const { onOpenHelp, onCloseHelp, selectedOptions, accordion, errorMessage } = this.props;
     const { isViewMoreRendered, itemsToShow } = this.state;
     const optionsToRender = this.getOptionsToRender(itemsToShow, isViewMoreRendered);
 
@@ -76,6 +76,7 @@ class ButtonsListSelect extends Component {
           selectedOptions={selectedOptions}
           onClick={this.handleClick}
           onOpenHelp={onOpenHelp}
+          onCloseHelp={onCloseHelp}
           accordion={accordion}
         />
         {isViewMoreRendered &&
@@ -94,6 +95,7 @@ ButtonsListSelect.propTypes = {
   onSelect: PropTypes.func.isRequired,
   onDeselect: PropTypes.func.isRequired,
   onOpenHelp: PropTypes.func,
+  onCloseHelp: PropTypes.func,
   isViewMoreEnabled: PropTypes.bool,
   itemsToShowFirstRender: PropTypes.number,
   itemsPerPage: PropTypes.number,

--- a/lib/components/ButtonsListSelectOption.jsx
+++ b/lib/components/ButtonsListSelectOption.jsx
@@ -22,10 +22,13 @@ class ButtonsListSelectOption extends Component {
 
   onClickTooltip = () => {
     const { opened } = this.state;
-    const { onClickHelp, value } = this.props;
+    const { onOpenHelp, value } = this.props;
 
     this.setState({ opened: !opened });
-    onClickHelp(value);
+
+    if (!opened) {
+      onOpenHelp(value, '?');
+    }
   };
 
   renderAccordion() {
@@ -73,7 +76,7 @@ ButtonsListSelectOption.propTypes = {
   accordion: PropTypes.bool,
   iconClass: PropTypes.string,
   onClick: PropTypes.func,
-  onClickHelp: PropTypes.func,
+  onOpenHelp: PropTypes.func,
   iconToolTip: PropTypes.func,
 };
 

--- a/lib/components/ButtonsListSelectOption.jsx
+++ b/lib/components/ButtonsListSelectOption.jsx
@@ -22,12 +22,14 @@ class ButtonsListSelectOption extends Component {
 
   onClickTooltip = () => {
     const { opened } = this.state;
-    const { onOpenHelp, value } = this.props;
+    const { onOpenHelp, onCloseHelp, value } = this.props;
 
     this.setState({ opened: !opened });
 
     if (!opened) {
       onOpenHelp(value, '?');
+    } else {
+      onCloseHelp(value, '?');
     }
   };
 
@@ -77,6 +79,7 @@ ButtonsListSelectOption.propTypes = {
   iconClass: PropTypes.string,
   onClick: PropTypes.func,
   onOpenHelp: PropTypes.func,
+  onCloseHelp: PropTypes.func,
   iconToolTip: PropTypes.func,
 };
 

--- a/lib/components/ButtonsListSelectOptions.jsx
+++ b/lib/components/ButtonsListSelectOptions.jsx
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 import ButtonsListSelectOption from './ButtonsListSelectOption';
 
 const ButtonsListSelectOptions = props => {
-  const { options, selectedOptions, onClick, onClickHelp, accordion } = props;
+  const { options, selectedOptions, onClick, onOpenHelp, accordion } = props;
 
   return (
     <ul className="buttons-list-select-options">
@@ -16,7 +16,7 @@ const ButtonsListSelectOptions = props => {
           iconClass={option.iconClass}
           infoText={option.infoText}
           onClick={onClick}
-          onClickHelp={onClickHelp}
+          onOpenHelp={onOpenHelp}
           selected={selectedOptions.includes(option.value)}
           accordion={accordion}
         />
@@ -31,7 +31,7 @@ ButtonsListSelectOptions.propTypes = {
     label: PropTypes.string,
   }).isRequired).isRequired,
   onClick: PropTypes.func,
-  onClickHelp: PropTypes.func,
+  onOpenHelp: PropTypes.func,
   accordion: PropTypes.bool,
   selectedOptions: PropTypes.arrayOf(PropTypes.string),
 };

--- a/lib/components/ButtonsListSelectOptions.jsx
+++ b/lib/components/ButtonsListSelectOptions.jsx
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 import ButtonsListSelectOption from './ButtonsListSelectOption';
 
 const ButtonsListSelectOptions = props => {
-  const { options, selectedOptions, onClick, onOpenHelp, accordion } = props;
+  const { options, selectedOptions, onClick, onOpenHelp, onCloseHelp, accordion } = props;
 
   return (
     <ul className="buttons-list-select-options">
@@ -17,6 +17,7 @@ const ButtonsListSelectOptions = props => {
           infoText={option.infoText}
           onClick={onClick}
           onOpenHelp={onOpenHelp}
+          onCloseHelp={onCloseHelp}
           selected={selectedOptions.includes(option.value)}
           accordion={accordion}
         />
@@ -32,6 +33,7 @@ ButtonsListSelectOptions.propTypes = {
   }).isRequired).isRequired,
   onClick: PropTypes.func,
   onOpenHelp: PropTypes.func,
+  onCloseHelp: PropTypes.func,
   accordion: PropTypes.bool,
   selectedOptions: PropTypes.arrayOf(PropTypes.string),
 };

--- a/lib/components/__tests__/ButtonsListSelect.test.jsx
+++ b/lib/components/__tests__/ButtonsListSelect.test.jsx
@@ -155,10 +155,30 @@ describe('Buttons List Select', () => {
     });
   });
 
+  describe('help button', () => {
+    it('calls onOpenHelp the first time is clicked', () => {
+      const component = renderComponent();
+      const firstOption = getOptions(component).first();
+      clickHelpButton(component);
+
+      expect(DEFAULT_ON_OPEN_HELP).toBeCalledWith(firstOption.props().value, getHelpIcon(component));
+    });
+
+    it('calls onCloseHelp the second time is clicked', () => {
+      const component = renderComponent();
+      const firstOption = getOptions(component).first();
+      clickHelpButton(component);
+
+      expect(DEFAULT_ON_OPEN_HELP).toBeCalledWith(firstOption.props().value, getHelpIcon(component));
+    });
+  });
+
   const DEFAULT_OPTIONS_FIRST_PAGE = 2;
   const DEFAULT_OPTIONS_PER_PAGE = 3;
   const DEFAULT_ON_SELECT_CALLBACK = jest.fn();
   const DEFAULT_ON_DESELECT_CALLBACK = jest.fn();
+  const DEFAULT_ON_OPEN_HELP = jest.fn();
+  const DEFAULT_ON_CLOSE_HELP = jest.fn();
   const EXAMPLE_INSURANCE_TYPE = {
     label: 'Business Owners Policy (BOP)',
     value: 'Business Owners Policy (BOP)',
@@ -178,6 +198,8 @@ describe('Buttons List Select', () => {
     onDeselect: DEFAULT_ON_DESELECT_CALLBACK,
     itemsToShowFirstRender: DEFAULT_OPTIONS_FIRST_PAGE,
     itemsPerPage: DEFAULT_OPTIONS_PER_PAGE,
+    onOpenHelp: DEFAULT_ON_OPEN_HELP,
+    onCloseHelp: DEFAULT_ON_CLOSE_HELP,
   };
 
 
@@ -188,6 +210,8 @@ describe('Buttons List Select', () => {
   const getViewMoreButton = component => component.find('.button-view-more');
   const getAccordion = component => component.find('AccordionSelect');
   const getErrorMessage = component => component.find('.error-message');
+  const getHelpButton = (component, index) => component.find('QuestionIcon').at(index).parent();
+  const getHelpIcon = component => component.find('QuestionIcon').at(0).text();
 
   const clickViewMore = component => {
     getViewMoreButton(component).simulate('click');
@@ -196,6 +220,11 @@ describe('Buttons List Select', () => {
 
   const clickTitleOption = (option, component) => {
     option.find('TextWithIcon').find('.wide-button__title-item').simulate('click');
+    component.update();
+  };
+
+  const clickHelpButton = (component, index = 0) => {
+    getHelpButton(component, index).simulate('click');
     component.update();
   };
 });

--- a/lib/components/__tests__/ButtonsListSelect.test.jsx
+++ b/lib/components/__tests__/ButtonsListSelect.test.jsx
@@ -158,14 +158,27 @@ describe('Buttons List Select', () => {
 
   describe('help button', () => {
     describe('on open', () => {
-      it('calls onOpenHelp if accordion is closed', () => {
+      it('calls onOpenHelp if accordion when clicked AND is closed', () => {
         const component = renderComponent();
         const firstOption = getOptions(component).first();
         clickHelpButton(component);
         const infoText = getOptionInfoText(component);
 
         expect(DEFAULT_ON_OPEN_HELP).toBeCalledWith(firstOption.props().value, getHelpIcon(component).trim());
-        expect(isTextRendered(component, infoText)).toBeTruthy();
+        expect(isHelpRendered(component, infoText)).toBeTruthy();
+      });
+    });
+
+    describe('on close', () => {
+      it('calls onCloseHelp when clicked AND is opened', () => {
+        const component = renderComponent();
+        const firstOption = getOptions(component).first();
+        clickHelpButton(component);
+        clickHelpButton(component);
+        const infoText = getOptionInfoText(component);
+
+        expect(DEFAULT_ON_CLOSE_HELP).toBeCalledWith(firstOption.props().value, getHelpIcon(component).trim());
+        expect(isHelpRendered(component, infoText)).toBeFalsy();
       });
     });
   });
@@ -187,7 +200,7 @@ describe('Buttons List Select', () => {
     [0, 1, 2, 3, 4, 5, 6, 7].map(key => (
       { ...EXAMPLE_INSURANCE_TYPE,
         value: EXAMPLE_INSURANCE_TYPE.value + key,
-        infoText: EXAMPLE_INSURANCE_TYPE.value + key,
+        infoText: `${EXAMPLE_INSURANCE_TYPE.value + key}tooltip`,
       }
     ))
   );
@@ -232,8 +245,6 @@ describe('Buttons List Select', () => {
     component.update();
   };
 
-  const isTextRendered = (component, text) =>
-    !!component.findWhere(
-      node => node && node.length && node.type() && node.text() === text,
-    ).length;
+  const isHelpRendered = (component, text) =>
+    component.find('.wide-button__content--opened').length && component.find('.wide-button__content--opened').text() === text;
 });

--- a/lib/components/__tests__/ButtonsListSelect.test.jsx
+++ b/lib/components/__tests__/ButtonsListSelect.test.jsx
@@ -133,7 +133,8 @@ describe('Buttons List Select', () => {
     });
 
     it('does NOT render Accordion if "accordion" prop is NOT passed OR passed as false', () => {
-      const component = renderComponent();
+      const testProps = setProps({ accordion: false });
+      const component = renderComponent(testProps);
       const accordion = getAccordion(component);
 
       expect(accordion.exists()).toBeFalsy();
@@ -156,20 +157,16 @@ describe('Buttons List Select', () => {
   });
 
   describe('help button', () => {
-    it('calls onOpenHelp the first time is clicked', () => {
-      const component = renderComponent();
-      const firstOption = getOptions(component).first();
-      clickHelpButton(component);
+    describe('on open', () => {
+      it('calls onOpenHelp if accordion is closed', () => {
+        const component = renderComponent();
+        const firstOption = getOptions(component).first();
+        clickHelpButton(component);
+        const infoText = getOptionInfoText(component);
 
-      expect(DEFAULT_ON_OPEN_HELP).toBeCalledWith(firstOption.props().value, getHelpIcon(component));
-    });
-
-    it('calls onCloseHelp the second time is clicked', () => {
-      const component = renderComponent();
-      const firstOption = getOptions(component).first();
-      clickHelpButton(component);
-
-      expect(DEFAULT_ON_OPEN_HELP).toBeCalledWith(firstOption.props().value, getHelpIcon(component));
+        expect(DEFAULT_ON_OPEN_HELP).toBeCalledWith(firstOption.props().value, getHelpIcon(component).trim());
+        expect(isTextRendered(component, infoText)).toBeTruthy();
+      });
     });
   });
 
@@ -187,7 +184,12 @@ describe('Buttons List Select', () => {
   };
 
   const createOptionsExample = () => (
-    [0, 1, 2, 3, 4, 5, 6, 7].map(key => ({ ...EXAMPLE_INSURANCE_TYPE, value: EXAMPLE_INSURANCE_TYPE.value + key }))
+    [0, 1, 2, 3, 4, 5, 6, 7].map(key => (
+      { ...EXAMPLE_INSURANCE_TYPE,
+        value: EXAMPLE_INSURANCE_TYPE.value + key,
+        infoText: EXAMPLE_INSURANCE_TYPE.value + key,
+      }
+    ))
   );
 
   const EXAMPLE_OPTIONS = createOptionsExample();
@@ -200,6 +202,7 @@ describe('Buttons List Select', () => {
     itemsPerPage: DEFAULT_OPTIONS_PER_PAGE,
     onOpenHelp: DEFAULT_ON_OPEN_HELP,
     onCloseHelp: DEFAULT_ON_CLOSE_HELP,
+    accordion: true,
   };
 
 
@@ -210,8 +213,9 @@ describe('Buttons List Select', () => {
   const getViewMoreButton = component => component.find('.button-view-more');
   const getAccordion = component => component.find('AccordionSelect');
   const getErrorMessage = component => component.find('.error-message');
-  const getHelpButton = (component, index) => component.find('QuestionIcon').at(index).parent();
+  const getHelpButton = (component, index = 0) => component.find('QuestionIcon').at(index).parent();
   const getHelpIcon = component => component.find('QuestionIcon').at(0).text();
+  const getOptionInfoText = (component, index = 0) => component.find('ButtonsListSelectOption').at(index).props().infoText;
 
   const clickViewMore = component => {
     getViewMoreButton(component).simulate('click');
@@ -227,4 +231,9 @@ describe('Buttons List Select', () => {
     getHelpButton(component, index).simulate('click');
     component.update();
   };
+
+  const isTextRendered = (component, text) =>
+    !!component.findWhere(
+      node => node && node.length && node.type() && node.text() === text,
+    ).length;
 });

--- a/lib/stylesheets/components/_wide_button.scss
+++ b/lib/stylesheets/components/_wide_button.scss
@@ -115,7 +115,7 @@
       position: relative;
       display: block;
       padding: 24px;
-      border: 1px solid $cwColor-gray-light;
+      border-top: 1px solid $cwColor-gray-light;
       background-color: $cwColor-blue-lightest;
       border-bottom-left-radius: 10px;
       border-bottom-right-radius: 10px;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cw-components",
-  "version": "2.14.1",
+  "version": "2.15.0",
   "description": "CoverWallet components",
   "main": "./build/lib/index.js",
   "repository": {


### PR DESCRIPTION
### Where

* **JIRA Story:** 
https://coverwallet.atlassian.net/browse/ACQ-542
https://coverwallet.atlassian.net/browse/ACQ-652

### What

- Add 2 differents callbacks for open and close accordion (aka tooltip), so we can do different things when the accordion is open or closed.
- Fix styles of the accordion because the borders of the accordion opened were being duplicated.

### Test

`yarn test lib/components/__tests__/ButtonsListSelect.test.jsx`
