### PR TITLE
Adding withArrows prop to OnlyClickListOptions

### DIFF
--- a/examples/basic/app.js
+++ b/examples/basic/app.js
@@ -404,6 +404,21 @@ const App = function App() {
       <hr />
 
       <div>
+        <h2>Only Click List Options (with no arrow)</h2>
+
+        <div>
+          <OnlyClickListOptions
+            options={iconRadioGroupOptions}
+            onClick={(value) => console.log('You choose ', value)}
+            selectedValues={['Yes']}
+            continueOnClick={false}
+          />
+        </div>
+      </div>
+
+      <hr />
+
+      <div>
         <h2>Only Click Select</h2>
 
         <h4>Icons view with auto focus</h4>

--- a/examples/basic/app.js
+++ b/examples/basic/app.js
@@ -404,14 +404,14 @@ const App = function App() {
       <hr />
 
       <div>
-        <h2>Only Click List Options (with no arrow)</h2>
+        <h2>Only Click List Options (with no arrows)</h2>
 
         <div>
           <OnlyClickListOptions
             options={iconRadioGroupOptions}
             onClick={(value) => console.log('You choose ', value)}
             selectedValues={['Yes']}
-            continueOnClick={false}
+            withArrows={false}
           />
         </div>
       </div>

--- a/lib/components/OnlyClickListOption.jsx
+++ b/lib/components/OnlyClickListOption.jsx
@@ -23,7 +23,7 @@ function OnlyClickListOption(props) {
     disabled,
     optionComponent,
     animatedSelection = true,
-    continueOnClick = true,
+    withArrow = true,
   } = props;
   const optionClass = classNames(
     itemClasses,
@@ -38,7 +38,7 @@ function OnlyClickListOption(props) {
   const messageClass = classNames('oc-option__message');
   const multiSelectIconClass = classNames('oc-option__checked-icon', { 'oc-option__checked-icon--checked': checked });
   const tooltipIconClass = classNames('oc-option__help-icon', { 'oc-option__help-icon--checked': checked });
-  const hasNextIcon = listType !== 'multiSelect' && continueOnClick;
+  const hasNextIcon = listType !== 'multiSelect' && withArrow;
 
   return (
     <li id={id} className={optionClass} onClick={() => !disabled && onClick(value)} disabled={disabled}>
@@ -87,7 +87,7 @@ OnlyClickListOption.propTypes = {
   onClick: PropTypes.func,
   onHelpClick: PropTypes.func,
   optionComponent: PropTypes.func,
-  continueOnClick: PropTypes.bool,
+  withArrow: PropTypes.bool,
 };
 
 export default OnlyClickListOption;

--- a/lib/components/OnlyClickListOption.jsx
+++ b/lib/components/OnlyClickListOption.jsx
@@ -23,6 +23,7 @@ function OnlyClickListOption(props) {
     disabled,
     optionComponent,
     animatedSelection = true,
+    withArrow = true,
   } = props;
   const optionClass = classNames(
     itemClasses,
@@ -37,6 +38,7 @@ function OnlyClickListOption(props) {
   const messageClass = classNames('oc-option__message');
   const multiSelectIconClass = classNames('oc-option__checked-icon', { 'oc-option__checked-icon--checked': checked });
   const tooltipIconClass = classNames('oc-option__help-icon', { 'oc-option__help-icon--checked': checked });
+  const hasNextIcon = listType !== 'multiSelect' && withArrow;
 
   return (
     <li id={id} className={optionClass} onClick={() => !disabled && onClick(value)} disabled={disabled}>
@@ -61,7 +63,7 @@ function OnlyClickListOption(props) {
           {tooltipKey && (
             <span className={tooltipIconClass} id={tooltipKey} onClick={onHelpClick && onHelpClick.bind(null, tooltipKey)} tabIndex="-1" />
           )}
-          {listType !== 'multiSelect' && <span className="oc-option__next-icon" />}
+          {hasNextIcon && <span className="oc-option__next-icon" />}
         </span>
       )}
     </li>
@@ -85,6 +87,7 @@ OnlyClickListOption.propTypes = {
   onClick: PropTypes.func,
   onHelpClick: PropTypes.func,
   optionComponent: PropTypes.func,
+  withArrow: PropTypes.bool,
 };
 
 export default OnlyClickListOption;

--- a/lib/components/OnlyClickListOption.jsx
+++ b/lib/components/OnlyClickListOption.jsx
@@ -23,7 +23,7 @@ function OnlyClickListOption(props) {
     disabled,
     optionComponent,
     animatedSelection = true,
-    withArrow = true,
+    continueOnClick = true,
   } = props;
   const optionClass = classNames(
     itemClasses,
@@ -38,7 +38,7 @@ function OnlyClickListOption(props) {
   const messageClass = classNames('oc-option__message');
   const multiSelectIconClass = classNames('oc-option__checked-icon', { 'oc-option__checked-icon--checked': checked });
   const tooltipIconClass = classNames('oc-option__help-icon', { 'oc-option__help-icon--checked': checked });
-  const hasNextIcon = listType !== 'multiSelect' && withArrow;
+  const hasNextIcon = listType !== 'multiSelect' && continueOnClick;
 
   return (
     <li id={id} className={optionClass} onClick={() => !disabled && onClick(value)} disabled={disabled}>
@@ -87,7 +87,7 @@ OnlyClickListOption.propTypes = {
   onClick: PropTypes.func,
   onHelpClick: PropTypes.func,
   optionComponent: PropTypes.func,
-  withArrow: PropTypes.bool,
+  continueOnClick: PropTypes.bool,
 };
 
 export default OnlyClickListOption;

--- a/lib/components/OnlyClickListOptions.jsx
+++ b/lib/components/OnlyClickListOptions.jsx
@@ -17,7 +17,7 @@ function OnlyClickListOptions(props) {
     listClasses,
     optionComponent,
     animatedSelection,
-    continueOnClick,
+    withArrows,
   } = props;
 
   return (
@@ -41,7 +41,7 @@ function OnlyClickListOptions(props) {
           disabled={disabled || option.disabled}
           optionComponent={optionComponent}
           animatedSelection={animatedSelection}
-          continueOnClick={continueOnClick}
+          withArrow={withArrows}
         />
       ))}
     </ul>
@@ -61,7 +61,7 @@ OnlyClickListOptions.propTypes = {
   listClasses: PropTypes.string,
   disabled: PropTypes.bool,
   optionComponent: PropTypes.func,
-  continueOnClick: PropTypes.bool,
+  withArrows: PropTypes.bool,
 };
 
 export default OnlyClickListOptions;

--- a/lib/components/OnlyClickListOptions.jsx
+++ b/lib/components/OnlyClickListOptions.jsx
@@ -17,7 +17,7 @@ function OnlyClickListOptions(props) {
     listClasses,
     optionComponent,
     animatedSelection,
-    withArrows,
+    continueOnClick,
   } = props;
 
   return (
@@ -41,7 +41,7 @@ function OnlyClickListOptions(props) {
           disabled={disabled || option.disabled}
           optionComponent={optionComponent}
           animatedSelection={animatedSelection}
-          withArrow={withArrows}
+          continueOnClick={continueOnClick}
         />
       ))}
     </ul>
@@ -61,7 +61,7 @@ OnlyClickListOptions.propTypes = {
   listClasses: PropTypes.string,
   disabled: PropTypes.bool,
   optionComponent: PropTypes.func,
-  withArrows: PropTypes.bool,
+  continueOnClick: PropTypes.bool,
 };
 
 export default OnlyClickListOptions;

--- a/lib/components/OnlyClickListOptions.jsx
+++ b/lib/components/OnlyClickListOptions.jsx
@@ -17,6 +17,7 @@ function OnlyClickListOptions(props) {
     listClasses,
     optionComponent,
     animatedSelection,
+    withArrows,
   } = props;
 
   return (
@@ -40,6 +41,7 @@ function OnlyClickListOptions(props) {
           disabled={disabled || option.disabled}
           optionComponent={optionComponent}
           animatedSelection={animatedSelection}
+          withArrow={withArrows}
         />
       ))}
     </ul>
@@ -59,6 +61,7 @@ OnlyClickListOptions.propTypes = {
   listClasses: PropTypes.string,
   disabled: PropTypes.bool,
   optionComponent: PropTypes.func,
+  withArrows: PropTypes.bool,
 };
 
 export default OnlyClickListOptions;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cw-components",
-  "version": "2.16.5",
+  "version": "2.17.0",
   "description": "CoverWallet components",
   "main": "./build/lib/index.js",
   "repository": {


### PR DESCRIPTION
### What

Currently, we are hiding the arrows in `OnlyClickListOptions` components by css in SHF. In order to avoid doing that, we are adding a prop that will render conditionally those arrows.

<img width="1577" alt="image" src="https://user-images.githubusercontent.com/6910444/51980689-199ba780-2491-11e9-9ba9-e8156e2408e7.png">

### How

Adding the prop to `OnlyClickListOptions` and passing it down to `OnlyClickListOption`.
Updating minor package version.