### PR TITLE
Fixed ui when options provided have no addition value

### DIFF
--- a/lib/stylesheets/components/_oc_multi_select_dropdown.scss
+++ b/lib/stylesheets/components/_oc_multi_select_dropdown.scss
@@ -77,6 +77,7 @@
     padding: 7px 10px;
     display: table;
     width: 100%;
+    min-height: 54px;
   }
 
   &__content {
@@ -84,7 +85,7 @@
     display: none;
   }
 
-  &__head-info {
+  .oc-multi-select-dropdown &__head-info, &__head-info {
     vertical-align: middle;
   }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cw-components",
-  "version": "2.17.0",
+  "version": "2.17.1",
   "description": "CoverWallet components",
   "main": "./build/lib/index.js",
   "repository": {


### PR DESCRIPTION
### What

Options in `OnlyClickMultiSelectDropdown` component should maintain UI style even when there is no addition in the option object.

### How

Adding a min-height and giving a class more specificity to avoid styles from other class to affect it.

### Screenshots

Previous:
![image](https://user-images.githubusercontent.com/17853818/52203918-e7b08980-2872-11e9-98fc-be1832fa006c.png)
![image](https://user-images.githubusercontent.com/17853818/52203928-f303b500-2872-11e9-98c3-624377da0732.png)


With Change:
![image](https://user-images.githubusercontent.com/17853818/52203943-fd25b380-2872-11e9-9eec-fbea3c5b19b1.png)
