### PR TITLE
Fix: smallInput, grayBorder & noArrows for OnlyClickSelect

### DIFF
--- a/examples/basic/app.js
+++ b/examples/basic/app.js
@@ -549,6 +549,35 @@ const App = function App() {
           />
         </div>
 
+         <h4>List view with auto scroll, highlight and adition, with small input, gray border and drop-down list with no arrows and dropdown</h4>
+
+        <div>
+          <OnlyClickSelect
+            placeholder="Select"
+            options={industries[0].subindustries.map(subindustry => objectAssign({},
+              subindustry,
+              { label: subindustry.name, value: subindustry.name, addition: subindustry.name }
+            ))}
+            onChange={(value) => console.log('You typed ', value)}
+            onClick={(value) => console.log('You choose ', value)}
+            onDelete={(value) => console.log('You remove ', value)}
+            onEnterKeyPress={(value) => console.log('You pressed the Enter key')}
+            values={[industries[0].subindustries[0].name]}
+            maxVisible={10}
+            disableFilter
+            autoScroll
+            highlight
+            typedvalue={''}
+            scrollable
+            disableInput
+            dropdown
+            openedDropdown={false}
+            smallInput
+            grayBorder
+            noArrows
+          />
+        </div>
+
         <h4>With help icon and recommendable options</h4>
 
         <div>

--- a/lib/components/OnlyClickSelect.jsx
+++ b/lib/components/OnlyClickSelect.jsx
@@ -153,6 +153,9 @@ class OnlyClickSelect extends React.Component {
       scrollable,
       dropdown,
       openedDropdown,
+      smallInput,
+      grayBorder,
+      noArrows,
     } = this.props;
 
     const { values, typedValue, openDropdown } = this.state;
@@ -161,7 +164,12 @@ class OnlyClickSelect extends React.Component {
       'oc-select__options-container--scrollable': scrollable,
       'oc-select__options-container--dropdown': dropdown,
     });
-    const optionSearchClassName = classNames('oc-select__search', { 'oc-select__search--dropdown': dropdown });
+    const optionSearchClassName = classNames(
+      'oc-select__search',
+      { 'oc-select__search--dropdown': dropdown },
+      { 'oc-select__search--smallInput': smallInput },
+      { 'oc-select__search--grayBorder': grayBorder }
+    );
     const shouldRenderInput = !dropdown || values.length === 0;
 
     return (
@@ -211,6 +219,7 @@ class OnlyClickSelect extends React.Component {
                 typedValue={typedValue}
                 highlight={highlight}
                 highlightSanitizer={highlightSanitizer}
+                withArrows={!noArrows}
               />
             )}
           </div>
@@ -249,6 +258,9 @@ OnlyClickSelect.propTypes = {
   scrollable: PropTypes.bool,
   dropdown: PropTypes.bool,
   openedDropdown: PropTypes.bool,
+  smallInput: PropTypes.bool,
+  grayBorder: PropTypes.bool,
+  noArrows: PropTypes.bool,
 };
 
 OnlyClickSelect.defaultProps = {

--- a/lib/stylesheets/components/_oc_select.scss
+++ b/lib/stylesheets/components/_oc_select.scss
@@ -37,6 +37,15 @@
       }
     }
 
+    &--smallInput {
+      min-height: 38px;
+      padding: 2px 11px;
+    }
+
+    &--grayBorder {
+      border-color: $cwColor-gray-light;
+    }
+
     @include media($mobile) {
       font-size: 15px;
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cw-components",
-  "version": "2.19.4",
+  "version": "2.20.0",
   "description": "CoverWallet components",
   "main": "./build/lib/index.js",
   "repository": {


### PR DESCRIPTION
### What
Added 3 new options for OnlyClickSelect layout:

- smallInput: Make the input smaller.
- grayBorder: Make the border of the input gray.
- noArrows: Make the list has no arrows.

### Screenshot
![image](https://user-images.githubusercontent.com/33939360/52779982-90b46c80-3049-11e9-806f-b54b2033b9da.png)
