### PR TITLE
Add extra check to ensure methods onOpenHelp and onCloseHelp exists

### DIFF
--- a/lib/components/ButtonsListSelectOption.jsx
+++ b/lib/components/ButtonsListSelectOption.jsx
@@ -26,9 +26,9 @@ class ButtonsListSelectOption extends Component {
 
     this.setState({ opened: !opened });
 
-    if (!opened) {
+    if (!opened && onOpenHelp) {
       onOpenHelp(value, '?');
-    } else {
+    } else if (opened && onCloseHelp) {
       onCloseHelp(value, '?');
     }
   };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cw-components",
-  "version": "2.20.3",
+  "version": "2.20.4",
   "description": "CoverWallet components",
   "main": "./build/lib/index.js",
   "repository": {


### PR DESCRIPTION
### What

While using the ButtonsListSelect  component I have detected that we never check if methods `onOpenHelp`and `onCloseHelp` exists. I have added an extra check to determine if this methods exists to avoid their execution if they don't exists

### How

Simply by perform a check before execute it.