### PR TITLE
Fixing tooltip's position in icon options

### DIFF
--- a/lib/stylesheets/components/_oc_icon_options.scss
+++ b/lib/stylesheets/components/_oc_icon_options.scss
@@ -65,8 +65,8 @@
       @include cw-icon-before(question-circle, 0, $cwColor-base-blue);
       position: absolute;
       cursor: pointer;
-      top: -6px;
-      right: -10px;
+      top: -4px;
+      right: -8px;
       font-size: 18px;
       padding-left: 5px;
       z-index: 1;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cw-components",
-  "version": "2.22.0",
+  "version": "2.22.1",
   "description": "CoverWallet components",
   "main": "./build/lib/index.js",
   "repository": {


### PR DESCRIPTION
### Where

* **Jira Story:** https://coverwallet.atlassian.net/browse/AON-283

### What

Tooltip's position is different from design.

![image](https://user-images.githubusercontent.com/6910444/56667261-d034b000-66ad-11e9-8fdf-9a290ddd2434.png)

### How

Modifying position.

### Screenshots

Before:
![image](https://user-images.githubusercontent.com/6910444/56667103-7f24bc00-66ad-11e9-9ce2-0f8f5db6bca8.png)
After:
![image](https://user-images.githubusercontent.com/6910444/56667316-e93d6100-66ad-11e9-8f1a-5651e76a4925.png)
