### PR TITLE
Adding ability to show infoText if html is in prop for ButtonsList

### DIFF
--- a/lib/components/AccordionSelect.jsx
+++ b/lib/components/AccordionSelect.jsx
@@ -17,7 +17,10 @@ const AccordionSelect = ({ selected, opened, infoText, children, onClick }) => {
         className={`${addClassWithOpened('wide-button__content')} ${addClassWithSelected('wide-button__tooltip-text')}`}
         onClick={onClick}
       >
-        {infoText && <p className="wide-button__tooltip-text">{infoText}</p>}
+        {infoText && <p
+          className="wide-button__tooltip-text"
+          dangerouslySetInnerHTML={{ __html: infoText }}
+        />}
       </div>
     </li>
   );

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cw-components",
-  "version": "2.24.2",
+  "version": "2.24.3",
   "description": "CoverWallet components",
   "main": "./build/lib/index.js",
   "repository": {


### PR DESCRIPTION
### Where
* **JIRA Story:** https://coverwallet.atlassian.net/browse/AON-605

### What
We need to have ability to put new lines, make text bold and some other formatting for the infoText(ButtonsListSelect) in AON US SHF. We need it on FirmTypes Page, all firm types are added by CW and infoText also added only by CW team. User is not allowing to save manually any data. More info in screenshot provided.

### How
dangerouslySetInnerHTML={{ __html: infoText }}

### Screenshots
![image](https://user-images.githubusercontent.com/33116965/61867969-0ec24c80-aee1-11e9-845d-1f81e27477c6.png)