### PR TITLE
Create cards components

### DIFF
--- a/examples/basic/app.js
+++ b/examples/basic/app.js
@@ -20,10 +20,11 @@ import {
   ButtonsListSelect,
   Toggle,
   TooltipIcon,
+  CardGroup,
 } from '../../lib/index';
 import industries from './catalog_api_json/industries';
 import insuranceTypes from './catalog_api_json/insuranceTypes';
-
+import ContentSample from './sample-components/card-component-example';
 import './app.scss';
 
 const iconRadioGroupOptions = [
@@ -114,11 +115,23 @@ const baseRadioGroupOptions = [
   },
 ];
 
+
+const getItems = () => [
+    (<ContentSample
+      iconClass="oc-icon-option__icon administrative_services_and_building_maintenance"
+      title="Business Owners Policy (BOP)"
+      subtitle="General liability + Property bundle"
+      tooltip="iuhiu"
+      price="~$ 76"
+      priceDescription="per month"
+      phone="Call (98) 9789 7987"
+    />), (<div>Add your content here</div>),
+];
+
 const App = function App() {
   return (
     <div className="example">
       <h1>cw-components</h1>
-
       <div className="clearfix row">
         <h2>Flash Notifications</h2>
         <CwFlashNotification
@@ -677,6 +690,13 @@ const App = function App() {
           selectedOptions={['Business Owners Policy (BOP)']}
           accordion
           errorMessage="If errorMessage prop is present, it will be displayed here"
+        />
+      </div>
+
+      <div>
+        <h2>Card Group</h2>
+        <CardGroup
+          items={getItems()}
         />
       </div>
     </div>

--- a/examples/basic/app.scss
+++ b/examples/basic/app.scss
@@ -4,6 +4,7 @@
 // Require styleguide css for example app only
 @import "../../node_modules/cw-styleguide/sass/coverwallet-styleguide";
 @import "../../lib/stylesheets/main";
+@import "./sample-components/card-component-example";
 
 body {
   background: #f9f9f9;

--- a/examples/basic/sample-components/card-component-example.jsx
+++ b/examples/basic/sample-components/card-component-example.jsx
@@ -1,0 +1,47 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+const ContentSample = ({
+  iconClass,
+  title,
+  subtitle,
+  tooltip,
+  price,
+  priceDescription,
+  phone,
+}) => (
+  <div className="lob-card">
+    <div className="lob-card__info-section">
+      {iconClass && (
+        <span className="lob-card__icon-container">
+          <span className={iconClass}></span>
+        </span>
+      )}
+      <div className="lob-card__name">
+        <div className="lob-card__title">
+          {title} {tooltip && <span>{tooltip}</span>}
+        </div>
+        {subtitle && <div className="lob-card__subtitle">{subtitle}</div>}
+      </div>
+    </div>
+    <div className="lob-card__price-section">
+      <div className="lob-card__price">{price}</div>
+      <div className="lob-card__subtitle">{priceDescription}</div>
+      <div className="lob-card__subtitle">
+        <a>{phone}</a>
+      </div>
+    </div>
+  </div>
+);
+
+ContentSample.propTypes = {
+  iconClass: PropTypes.string,
+  title: PropTypes.string,
+  subtitle: PropTypes.string,
+  tooltip: PropTypes.string,
+  price: PropTypes.string,
+  priceDescription: PropTypes.string,
+  phone: PropTypes.string,
+};
+
+export default ContentSample;

--- a/examples/basic/sample-components/card-component-example.scss
+++ b/examples/basic/sample-components/card-component-example.scss
@@ -1,0 +1,39 @@
+
+.lob-card {
+    @include display(flex);
+    @include justify-content(flex-start);
+    @include flex-wrap(nowrap);
+    @include align-items(center);
+    height: 100%;
+    font-weight: 100;
+  
+    &__info-section {
+      width: 80%;
+    }
+  
+    &__icon-container {
+      font-size: 50px;
+    }
+  
+    &__price-section {
+      width: 20%;
+      text-align: center;
+    }
+  
+    &__name {
+      display: inline-block;
+    }
+  
+    &__title {
+      font-size: 20px;
+    }
+  
+    &__subtitle {
+      font-size: 12px;
+    }
+  
+    &__price {
+      font-size: 24px;
+    }
+  }
+  

--- a/lib/components/CardGroup.jsx
+++ b/lib/components/CardGroup.jsx
@@ -1,24 +1,21 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import classNames from 'classnames';
 
-const Card = ({ children }) => (
-  <div className="card-group__item">{children}</div>
-);
-
-Card.propTypes = {
-  children: PropTypes.any,
+const CardGroup = ({ items, className }) => {
+  const CardClasses = classNames('card-group', className);
+  return (
+    <div className={CardClasses}>
+      {items.map(item => (
+        <div className="card-group__item">{item}</div>
+      ))}
+    </div>
+  );
 };
-
-const CardGroup = ({ items }) => (
-  <div className="card-group">
-    {items.map(item => (
-      <Card>{item}</Card>
-    ))}
-  </div>
-);
 
 CardGroup.propTypes = {
   items: PropTypes.arrayOf(PropTypes.object).isRequired,
+  className: PropTypes.string,
 };
 
 export default CardGroup;

--- a/lib/components/CardGroup.jsx
+++ b/lib/components/CardGroup.jsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+const Card = ({ children }) => (
+  <div className="card-group__item">{children}</div>
+);
+
+Card.propTypes = {
+  children: PropTypes.any,
+};
+
+const CardGroup = ({ items }) => (
+  <div className="card-group">
+    {items.map(item => (
+      <Card>{item}</Card>
+    ))}
+  </div>
+);
+
+CardGroup.propTypes = {
+  items: PropTypes.arrayOf(PropTypes.object).isRequired,
+};
+
+export default CardGroup;

--- a/lib/index.js
+++ b/lib/index.js
@@ -26,6 +26,7 @@ import ButtonsListSelectOption from './components/ButtonsListSelectOption';
 import Toggle from './components/Toggle';
 import Tooltip from './components/Tooltip';
 import TooltipIcon from './components/TooltipIcon';
+import CardGroup from './components/CardGroup';
 
 export {
   Loader,
@@ -56,4 +57,5 @@ export {
   Toggle,
   Tooltip,
   TooltipIcon,
+  CardGroup,
 };

--- a/lib/stylesheets/components/_card.scss
+++ b/lib/stylesheets/components/_card.scss
@@ -1,0 +1,16 @@
+.card-group {
+  @include display(flex);
+  @include flex-direction(column);
+  @include flex-wrap(wrap);
+
+  &__item {
+    background-color: #fff;
+    border-radius: 3px;
+    height: 100px;
+    padding: 15px;
+    overflow: hidden;
+    margin: 8px 0;
+    border: 1px solid #ecf4f7;
+    box-shadow: 0px 3px 7px 1px #dce5e8;
+  }
+}

--- a/lib/stylesheets/components/_card.scss
+++ b/lib/stylesheets/components/_card.scss
@@ -6,7 +6,7 @@
   &__item {
     background-color: #fff;
     border-radius: 3px;
-    height: 100px;
+    min-height: 100px;
     padding: 15px;
     overflow: hidden;
     margin: 8px 0;

--- a/lib/stylesheets/components/_components.scss
+++ b/lib/stylesheets/components/_components.scss
@@ -22,3 +22,4 @@
 @import 'error_message';
 @import 'toggle';
 @import 'tooltip';
+@import 'card';

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cw-components",
-  "version": "2.24.2",
+  "version": "2.25.0",
   "description": "CoverWallet components",
   "main": "./build/lib/index.js",
   "repository": {


### PR DESCRIPTION
### What

We need to add a component like this

<img width="755" alt="Captura de pantalla 2019-08-27 a las 12 26 14" src="https://user-images.githubusercontent.com/10259582/63763874-e3f35b80-c8c5-11e9-8d6c-a740b8de003d.png">

only the card group container. This component should be capable to receive a child component to render it into each card.

### How

We have added a block on cw-components demo page. to see how it works

This is the result

<img width="598" alt="Captura de pantalla 2019-08-27 a las 14 45 26" src="https://user-images.githubusercontent.com/10259582/63772493-72bda380-c8d9-11e9-9bf3-3a7ebf7b40cd.png">

