### PR TITLE
Padding and spinners in number inputs

### DIFF
--- a/lib/stylesheets/components/_input_keyboard.scss
+++ b/lib/stylesheets/components/_input_keyboard.scss
@@ -24,6 +24,15 @@
     }
   }
 
+  input[type=number]::-webkit-inner-spin-button, 
+  input[type=number]::-webkit-outer-spin-button { 
+    -webkit-appearance: none; 
+  }
+
+  input[type=number] {
+    -moz-appearance: textfield;
+    padding-right: 10px;
+  }
 
   .input-keyboard__input {
     margin-bottom: 10px;

--- a/lib/stylesheets/components/_number_input.scss
+++ b/lib/stylesheets/components/_number_input.scss
@@ -54,7 +54,6 @@
   input[type=number]::-webkit-inner-spin-button, 
   input[type=number]::-webkit-outer-spin-button { 
     -webkit-appearance: none; 
-    margin: 0; 
   }
 
   input[type=number] {
@@ -72,6 +71,7 @@
     border: 1px solid $cwColor-black-light;
     border-radius: 0;
     box-sizing: border-box;
+    padding-right: 10px;
 
     @include media($mobile) {
       width: 100%;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "cw-components",
-  "version": "2.25.1",
+  "version": "2.25.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cw-components",
-  "version": "2.25.1",
+  "version": "2.25.2",
   "description": "CoverWallet components",
   "main": "./build/lib/index.js",
   "repository": {


### PR DESCRIPTION
### Where

_https://coverwallet.atlassian.net/browse/ACQ-1011_

### What

Last upload of cw-components (v2.25.1) left no padding when removing spinner. Also, a remaining spinner was found for input-keyboard classes. 

### How

Padding has been added and checked for all components (10px, as seen in similar components). Spinner has been removed for input-keyboard, as previously done for input[type+number].

