### PR TITLE
Fix naming in setNextValue func

### DIFF
--- a/lib/components/NumPadMobile.jsx
+++ b/lib/components/NumPadMobile.jsx
@@ -13,8 +13,8 @@ class NumPadMobile extends React.Component {
 
   setNextValue(nextValue) {
     this.setState({ value: nextValue });
-    if (this.props.setValue) {
-      this.props.setValue(nextValue);
+    if (this.props.onChange) {
+      this.props.onChange(nextValue);
     }
   }
 
@@ -58,7 +58,7 @@ NumPadMobile.propTypes = {
   type: PropTypes.string,
   maxLength: PropTypes.number,
   onBlur: PropTypes.func,
-  setValue: PropTypes.func,
+  onChange: PropTypes.func,
   placeholder: PropTypes.string,
   getValue: PropTypes.func,
   disabled: PropTypes.bool,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cw-components",
-  "version": "2.26.2",
+  "version": "2.26.3",
   "description": "CoverWallet components",
   "main": "./build/lib/index.js",
   "repository": {


### PR DESCRIPTION
### What

Fix naming in SetNextValue function, because setValue was never passed from the father component.