### PR TITLE
AONC1449 - Fix Radio button's inconsistent behavior

### DIFF
--- a/lib/stylesheets/components/_checkbox_icon.scss
+++ b/lib/stylesheets/components/_checkbox_icon.scss
@@ -5,6 +5,7 @@
   color: gray;
   font-size: 14px;
   width: 35px;
+  height: 100%;
 
   &:before,
   &--checked:before {

--- a/lib/stylesheets/components/_wide_button.scss
+++ b/lib/stylesheets/components/_wide_button.scss
@@ -92,7 +92,6 @@
   &__title {
     $parent: &;
     width: 100%;
-    padding: 18px 0px;
     height: 64px;
     display: flex;
     align-items: center;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cw-components",
-  "version": "2.31.2",
+  "version": "2.32.0",
   "description": "CoverWallet components",
   "main": "./build/lib/index.js",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cw-components",
-  "version": "2.31.1",
+  "version": "2.31.2",
   "description": "CoverWallet components",
   "main": "./build/lib/index.js",
   "repository": {


### PR DESCRIPTION
### Where

* **Pivotal Story:** https://coverwallet.atlassian.net/browse/AONC-1449

### What

Bizpack upfront selection buttons are not being selected when the customer clicks them close to the left end

### Steps to reproduce

1. Get to the BI4 upfront selection page
2. Click any of the coverages' buttons close to the left end

### Expected result

The coverage should become selected/deselected

### Actual result

The button does an animation but the coverage does not get selected/deselected