### PR TITLE
CHORE / Remove deprecated flex mixins

### DIFF
--- a/examples/basic/sample-components/card-component-example.scss
+++ b/examples/basic/sample-components/card-component-example.scss
@@ -1,9 +1,9 @@
 
 .lob-card {
-    @include display(flex);
-    @include justify-content(flex-start);
-    @include flex-wrap(nowrap);
-    @include align-items(center);
+    display: flex;
+    justify-content: flex-start;
+    flex-wrap: nowrap;
+    align-items: center;
     height: 100%;
     font-weight: 100;
   

--- a/lib/stylesheets/components/_card.scss
+++ b/lib/stylesheets/components/_card.scss
@@ -1,7 +1,7 @@
 .card-group {
-  @include display(flex);
-  @include flex-direction(column);
-  @include flex-wrap(wrap);
+  display: flex;
+  flex-direction: column;
+  flex-wrap: wrap;
 
   &__item {
     background-color: #fff;

--- a/lib/stylesheets/components/_cw_flash_notification.scss
+++ b/lib/stylesheets/components/_cw_flash_notification.scss
@@ -1,7 +1,7 @@
 .cw-flash-notification {
   position: relative;
-  @include display(flex);
-  @include align-items(center);
+  display: flex;
+  align-items: center;
   min-height: 56px;
 
   &--info {
@@ -41,7 +41,7 @@
   }
 
   &__icon-container {
-    @include flex(0 0 42px);
+    flex: 0 0 42px;
     padding: 0 10px;
 
     @include media($mobile) {
@@ -60,11 +60,11 @@
   }
 
   &__content {
-    @include flex(1);
-    @include display(flex);
-    @include align-items(center);
-    @include justify-content(center);
-    @include flex-direction(column);
+    flex: 1;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    flex-direction: column;
     padding: 5px 0;
 
     @include media($mobile) {

--- a/lib/stylesheets/components/_icons_radio_group.scss
+++ b/lib/stylesheets/components/_icons_radio_group.scss
@@ -2,10 +2,10 @@
   @include clearfix();
 
   @include media($mobile) {
-    @include display(flex);
-    @include flex-wrap(wrap);
-    @include align-content(center);
-    @include justify-content(center);
+    display: flex;
+    flex-wrap: wrap;
+    align-content: center;
+    justify-content: center;
   }
 
   &--disabled {

--- a/lib/stylesheets/components/_oc_icon_options.scss
+++ b/lib/stylesheets/components/_oc_icon_options.scss
@@ -14,11 +14,11 @@
 }
 
 .oc-icon-options {
-  @include display(flex);
-  @include flex-wrap(wrap);
-  @include align-items(stretch);
-  @include align-content(space-between);
-  @include justify-content(flex-start);
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  align-content: space-between;
+  justify-content: flex-start;
   margin: 5px -10px 0 -10px;
 
   @include media($mobile) {
@@ -26,7 +26,7 @@
   }
 
   .oc-icon-option-container {
-    @include display(flex);
+    display: flex;
     width: 15.31111%;
     box-sizing: border-box;
     margin: 0 0.6777777%;

--- a/lib/stylesheets/components/_oc_select.scss
+++ b/lib/stylesheets/components/_oc_select.scss
@@ -9,8 +9,8 @@
   }
 
   .oc-select__search {
-    @include display(flex);
-    @include flex-wrap(wrap);
+    display: flex;
+    flex-wrap: wrap;
     z-index: 1;
     padding: 6px 11px;
     border: 1px solid $cwColor-base-blue;
@@ -52,7 +52,7 @@
   }
 
   .oc-select__input-container {
-    @include display(inline-flex);
+    display: inline-flex;
     width: 250px;
     max-width: 100%;
   }

--- a/lib/stylesheets/components/_oc_selected_value.scss
+++ b/lib/stylesheets/components/_oc_selected_value.scss
@@ -1,5 +1,5 @@
 .oc-selected-value {
-  @include display(inline-flex);
+  display: inline-flex;
   float: left;
   font-size: 0.9em;
   color: $cwColor-base-white;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "cw-components",
-  "version": "2.33.1",
+  "version": "2.34.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cw-components",
-  "version": "2.33.1",
+  "version": "2.34.0",
   "description": "CoverWallet components",
   "main": "./build/lib/index.js",
   "repository": {


### PR DESCRIPTION
### Where

### What

We have a lot of warnings due to use of outdated styles
![image](https://user-images.githubusercontent.com/41367151/77326440-e0746580-6d2a-11ea-904b-e77b3084ba02.png)
![image](https://user-images.githubusercontent.com/41367151/77326471-ea966400-6d2a-11ea-822b-9d0fdc978754.png)

This is happening because we use deprecated bourbon flexbox mixins
https://www.bourbon.io/docs/4/#flexbox

Flexbox is fully supported by all browsers, so we dont have to use external tools.
![image](https://user-images.githubusercontent.com/41367151/77326800-6395bb80-6d2b-11ea-9a65-73e260c47d66.png)

### How

Change bourbone mixins to regular flexbox styles

