### PR TITLE
DBS 3284 - Add data-test to CWFlashNotification

### DIFF
--- a/lib/components/CwFlashNotification.jsx
+++ b/lib/components/CwFlashNotification.jsx
@@ -13,7 +13,7 @@ class CwFlashNotification extends React.Component {
   closeNotification = () => {
     this.setState({
       closed: true,
-    })
+    });
   };
 
   render() {

--- a/lib/components/CwFlashNotification.jsx
+++ b/lib/components/CwFlashNotification.jsx
@@ -18,7 +18,7 @@ class CwFlashNotification extends React.Component {
 
   render() {
     const { closed } = this.state;
-    const { type, title, subtitle, subtitleMobile, largeTitle, largeTitleMobile, titleMobile, onClose } = this.props;
+    const { type, title, subtitle, subtitleMobile, largeTitle, largeTitleMobile, titleMobile, onClose, dataTest } = this.props;
     if (!onClose && closed) {
       return false;
     }
@@ -30,7 +30,7 @@ class CwFlashNotification extends React.Component {
     const handleClose = onClose || this.closeNotification;
 
     return (
-      <div className={notificationClass}>
+      <div className={notificationClass} data-test={dataTest}>
         <aside className="cw-flash-notification__icon-container">
           <i className="cw-flash-notification__icon" />
         </aside>
@@ -67,6 +67,7 @@ CwFlashNotification.propTypes = {
   subtitleMobile: PropTypes.string,
   largeTitleMobile: PropTypes.string,
   titleMobile: PropTypes.string,
+  dataTest: PropTypes.string,
 };
 
 export default CwFlashNotification;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "cw-components",
-  "version": "2.34.0",
+  "version": "2.35.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cw-components",
-  "version": "2.34.0",
+  "version": "2.35.0",
   "description": "CoverWallet components",
   "main": "./build/lib/index.js",
   "repository": {


### PR DESCRIPTION
### Where

* **JIRA Story:** https://coverwallet.atlassian.net/browse/DBS-3284

### What

We need to add a `data-test` to the parent container of the flash notification. This `data-test` is used in cypress tests.

