### PR TITLE
add ref for components in wallet-admin

### DIFF
--- a/lib/components/CurrencyInput.jsx
+++ b/lib/components/CurrencyInput.jsx
@@ -80,7 +80,7 @@ class CurrencyInput extends React.Component {
   }
 
   handleChange = e => {
-    this.setNextValue(e.target.value,e);
+    this.setNextValue(e.target.value);
   };
 
   render() {

--- a/lib/components/CurrencyInput.jsx
+++ b/lib/components/CurrencyInput.jsx
@@ -80,11 +80,11 @@ class CurrencyInput extends React.Component {
   }
 
   handleChange = e => {
-    this.setNextValue(e.target.value);
+    this.setNextValue(e.target.value,e);
   };
 
   render() {
-    const { name, min, max, currencyType = 'dollar', width, onBlur, autoFocus, disabled, showNumpadKeyboard } = this.props;
+    const { name, min, max, currencyType = 'dollar', width, onBlur, autoFocus, disabled, showNumpadKeyboard, innerRef } = this.props;
     const inputClass = classNames(
       'currency-input__input',
     );
@@ -92,7 +92,7 @@ class CurrencyInput extends React.Component {
       <div className="currency-input" style={{ width }}>
         <span className={`currency-input__icon currency-input__icon--${currencyType}`} />
         <input
-          ref="input"
+          ref={innerRef || 'input'}
           className={inputClass}
           type="text"
           pattern={showNumpadKeyboard ? '[0-9]*' : '.*'}
@@ -123,6 +123,7 @@ CurrencyInput.propTypes = {
     PropTypes.string,
     PropTypes.number,
   ]),
+  innerRef: PropTypes.func,
   name: PropTypes.string,
   min: PropTypes.number,
   max: PropTypes.number,

--- a/lib/components/IconRadioGroup.jsx
+++ b/lib/components/IconRadioGroup.jsx
@@ -80,6 +80,7 @@ IconRadioGroup.propTypes = {
   size: PropTypes.string,
   disabled: PropTypes.bool,
   className: PropTypes.string,
+  innerRef: PropTypes.func,
 };
 
 export default IconRadioGroup;

--- a/lib/components/IconRadioGroup.jsx
+++ b/lib/components/IconRadioGroup.jsx
@@ -39,7 +39,7 @@ class IconRadioGroup extends React.Component {
   };
 
   render() {
-    const { options, name, size, disabled, className } = this.props;
+    const { options, name, size, disabled, className, innerRef } = this.props;
     return (
       <div
         className={classNames(
@@ -52,6 +52,7 @@ class IconRadioGroup extends React.Component {
       >
         {options.map((option, i) => (
           <IconRadioInput
+            innerRef={innerRef}
             key={i}
             iconClass={option.iconClass}
             label={option.label}

--- a/lib/components/IconRadioInput.jsx
+++ b/lib/components/IconRadioInput.jsx
@@ -46,6 +46,7 @@ class IconRadioInput extends React.Component {
       recommendable,
       className,
       icon,
+      innerRef,
     } = this.props;
     const { checked } = this.state;
     const buttonClass = classNames(
@@ -60,10 +61,11 @@ class IconRadioInput extends React.Component {
     );
     const inputId = `${name}${value}`;
     return (
-      
+
       <label className={buttonClass} htmlFor={inputId}>
         {this.renderIcon()}
         <input
+          ref={innerRef}
           id={inputId}
           type="radio"
           name={name}

--- a/lib/components/IconRadioInput.jsx
+++ b/lib/components/IconRadioInput.jsx
@@ -98,6 +98,7 @@ IconRadioInput.propTypes = {
   disabled: PropTypes.bool,
   recommendable: PropTypes.bool,
   className: PropTypes.string,
+  innerRef: PropTypes.func,
 };
 
 export default IconRadioInput;


### PR DESCRIPTION
### What

Add ref to props in order to be able to set them instead of a fixed String

Related PR: https://github.com/coverwallet/cw-node-wallet-admin/pull/110