### PR TITLE
Fix onChange triggered twice on button click

### DIFF
--- a/lib/components/IconRadioGroup.jsx
+++ b/lib/components/IconRadioGroup.jsx
@@ -17,9 +17,6 @@ class IconRadioGroup extends React.Component {
       this.setState({
         value: nextProps.value,
       });
-      if (nextProps.onChange) {
-        nextProps.onChange(nextProps.value);
-      }
     }
   }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "cw-components",
-  "version": "2.36.1",
+  "version": "2.36.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cw-components",
-  "version": "2.36.1",
+  "version": "2.36.2",
   "description": "CoverWallet components",
   "main": "./build/lib/index.js",
   "repository": {


### PR DESCRIPTION
### Where

* **Pivotal Story:** https://coverwallet.atlassian.net/browse/IN-2874

### What

clicking on button triggers onChange 2 times.

before:
![image](https://user-images.githubusercontent.com/28709273/87144161-ff820d80-c2af-11ea-9ad7-e1978a979b43.png)


after:
![image](https://user-images.githubusercontent.com/28709273/87143904-93070e80-c2af-11ea-9976-b89dab12c8b5.png)
