### PR TITLE
LANN-2904 add ref prop to inputKeyboard

### DIFF
--- a/lib/components/InputKeyboard.jsx
+++ b/lib/components/InputKeyboard.jsx
@@ -91,7 +91,7 @@ class InputKeyboard extends React.Component {
   };
 
   render() {
-    const { min, currency, currencyType = 'dollar', commas, width, onBlur, type, autoFocus, maxLength, negatives, showNumpadKeyboard, name } = this.props;
+    const { min, currency, currencyType = 'dollar', commas, width, onBlur, type, autoFocus, maxLength, negatives, showNumpadKeyboard, name, innerRef } = this.props;
     const inputClass = classNames(
       'input-keyboard__input',
       { 'input-keyboard__input--currency': currency },
@@ -102,7 +102,7 @@ class InputKeyboard extends React.Component {
       <div className="input-keyboard" style={{ width }}>
         {currency && <span className={`input-keyboard__currency input-keyboard__currency--${currencyType}-icon`} />}
         <input
-          ref="input"
+          ref={innerRef || 'input'}
           name={name}
           type={(commas || showNumpadKeyboard) ? 'text' : type}
           className={inputClass}
@@ -132,6 +132,7 @@ InputKeyboard.propTypes = {
     PropTypes.number,
   ]),
   type: PropTypes.string,
+  innerRef: PropTypes.func,
   min: PropTypes.number,
   name: PropTypes.string,
   currency: PropTypes.bool,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "cw-components",
-  "version": "2.36.3",
+  "version": "2.36.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cw-components",
-  "version": "2.36.3",
+  "version": "2.36.4",
   "description": "CoverWallet components",
   "main": "./build/lib/index.js",
   "repository": {


### PR DESCRIPTION
### Where

_Provide links as references with information regarding this changes_

* **Pivotal Story:** https://coverwallet.atlassian.net/browse/LANN-2904
* **Related PRs:** https://github.com/coverwallet/cw-node-wallet-frontend/pull/69

### What

Add `ref` prop to `InputKeyboard` component so it can be used with `react-hook-form`
